### PR TITLE
Tippfehler behoben, kleinere inhaltliche Unklarheiten beseitigt, Formulierungen verbessert

### DIFF
--- a/document.tex
+++ b/document.tex
@@ -389,7 +389,7 @@ Damit gilt zusammenfassend
 \begin{align*}
 \sum_{i = 1}^N \dot{\vec{p}}_i \delta \vec{r}_i &= \sum_{i=1}^N \sum_{j = 1}^S m_i \left( \dd{t} (\dotvec{r}_i  \ffpartial{\dot{\vec{r}}_i}{\dot{q}_j})  -\dot{\vec{r}}_i \ffpartial{\dotvec r_i}{q_j} \right) \delta q_j\\ 
 &= \sum_{i=1}^N\sum_{j=1}^S m_i \left(  \dd{t} (\fpartial{\dot q_j} \frac12 \dotvec{r}_i^2) -\fpartial{q_j} (\frac12 \dot{\vec{r}}_i^2) \right) \delta q_j \\
-&= \sum_{j = 1}^S \left( \dd{t} \fpartial{\dot{q}_j} T - \ffpartial{T}{q_j} \right) \delta q_j
+&= \sum_{j = 1}^S \left( \dd{t} \ffpartial{T}{\dot{q}_j} - \ffpartial{T}{q_j} \right) \delta q_j
 \end{align*}
 Hierbei ist $T = \sum_{i = 1}^{N} \frac12 m_i \dot{\vec{r}}_i^2$ die "`Kinetische Energie"'
 und damit gilt mit dem d'Alembertsches Prinzip

--- a/document.tex
+++ b/document.tex
@@ -121,10 +121,10 @@
 \begin{description}
 	\item[Michelson-Morley] Es wurde gezeigt, dass es keinen "`Äther"' gibt, durch den sich das Licht bewegt und dass die Lichtgeschwindigkeit konstant ist.
 	\item[\conseq] \textbf{Spezielle Relativitätstheorie} auf die in einem späteren Kapitel noch eingegangen wird.
-	\item[Diskrete Emmisionsspektren (Spektrallinien)] sind bei Strahlung emmitierenden Objekten messbar.
+	\item[Diskrete Emmisionsspektren (Spektrallinien)] sind bei Strahlung emittierenden Objekten messbar.
 	\item[Welleneigenschaft von Teilchen] vgl. die Spaltexperimente mit Elektronen \footnote{Aufbau: Elektronen werden auf einen Doppelspalt "`geschossen"'. Dahinter befindet sich in einiger Entfernung ein Detektor. Klassisch würde man erwarten, dass ein Elektron ein Teilchen ist und damit der Detektor nur auf zwei schmalen Streifen Elektronen detektiert. Im Experiment detektiert man dagegen ein Interferenzmuster, dass an Wellen erinnert. Vgl. \href{http://de.wikipedia.org/wiki/Doppelspaltexperiment}{Wikipedia}} \conseq Widerspruch zur klassischen Physik, denn es sind nur die Wahrscheinlichkeiten vorhersagbar mit der sich ein Elektron zu einem bestimmten Zeitpunkt an einem bestimmten Ort befindet.
 	\item[Teilcheneigenschaften von Lichtwellen] vgl. \href{http://de.wikipedia.org/wiki/Photoelektrischer_Effekt}{Photoelektrischer-Effekt}
-	\item[Schwarzkörperspektrum] Abhängigkeit des emittierten Lichtspektrums eines Körpers/Gases von des Temperatur. Das (rein gedankliche) Schwarzkörperspektrum widerspricht der Boltzman-Verteilung. Daraus folgerte Plank, dass die untersuchten Teilchen (des Gases oder Körpers) ununterscheidbar oder identisch sind.
+	\item[Schwarzkörperspektrum] Abhängigkeit des emittierten Lichtspektrums eines Körpers/Gases von des Temperatur. Das (rein gedankliche) Schwarzkörperspektrum widerspricht der Boltzmann-Verteilung. Daraus folgerte Plank, dass die untersuchten Teilchen (des Gases oder Körpers) ununterscheidbar oder identisch sind.
 	\item[\conseq] \textbf{Quantenphysik} auf die in einem späteren Kapitel noch eingegangen wird.
 \end{description}
 Das nächste Kapitel behandelt die klassische Mechanik (ein Teilgebiet der klassischen Physik), da diese notwendig zum Verständnis der modernen Physik ist.
@@ -505,7 +505,7 @@ $$ \dd{t} \ffpartial{L}{\dot{q}_j} - \ffpartial{L}{q_j} = 0 \text{~für~} j= 1, 
 	\dd t \ffpartial{L}{\dot{q}_2} &= m_2 (l^2 \ddot{q}_2 + l \ddot{q}_1 \cos q_2 - l \dot{q}_1 \dot{q}_2 \sin q_2)\\
 	\ffpartial{L}{q_2} &= m_2 (- l \dot{q}_1 \dot{q}_2 \sin q_2 - g l \sin q_2)\\
 	0 &= m_2 (l^2 \ddot{q}_2 + l \ddot{q}_1 \cos q_2 + g l \sin q_2)\\
-	\intertext{Jetzt $\ddot{q}_1$ von oben (per Differentation)}
+	\intertext{Jetzt $\ddot{q}_1$ von oben (per Differentiation)}
 	\ddot{q}_1 &= - \frac{m_2 l}{m_1 + m_2} (\ddot{q}_2 \cos q_2 - \dot{q}_2^2 \sin q_2)
 	\end{align*}
 	Damit erhält man die $q_2$-Gleichung
@@ -560,7 +560,7 @@ Damit gilt für nicht-holonome Bedingungen in $q_j$
 
 Ein Vergleich mit den generalisierten Kräften zeigt $\bar{Q}_m = \sum_{i=1}^{p} \lambda_i a_{im}$
 Nun hat man generalisierte Zwangskräfte ($\sum_{m=1}^j \bar{Q}_m \delta q_m = 0$) was den $\lambda_i$ entspricht.
-Dieses Wissen ist auch ein Gewinn für Systeme mit holonomen Zangsbedingungen, denn die Kenntnis der Zwangskräfte ist nützlich für das Design des Systems.
+Dieses Wissen ist auch ein Gewinn für Systeme mit holonomen Zwangsbedingungen, denn die Kenntnis der Zwangskräfte ist nützlich für das Design des Systems.
 
 \textbf{Anwendung auf holonome Systeme}
 $f_i(\vardots{\vec{r}}{N}, t) = 0, i = 1, \dots, p$ in generalisierten Koordinaten $\bar{f}_i(\vardots{q}{j}, t) = 0$, daraus folgt das totale Differential 
@@ -602,11 +602,11 @@ Daraus folgen 3 Gleichungen
 \end{description}
 Randbemerkung: $\lambda = -m(l \dot{\varphi}^2 - g \cos \varphi)$ ist hier die Fadenspannung.
 
-Das ganze kann man vereinfachen wenn man $\dot{r} = 0$ und $\sin \varphi \approx \varphi$ annimmt (letzteres gilt für klein $\varphi$). Damit gilt dann folgendes ($\ddot{\vp} + \frac{g}{l} \vp = 0$
+Das ganze kann man vereinfachen wenn man $\dot{r} = 0$ und $\sin \varphi \approx \varphi$ annimmt (letzteres gilt für kleine $\varphi$). Damit gilt dann folgendes ($\ddot{\vp} + \frac{g}{l} \vp = 0$)
 $$\varphi(t) = \varphi_0 \sin \sqrt{\frac{g}{l}} t$$
 \end{beispiel*}
 
-\subsection{Das Hamiltonische Prinzip}	
+\subsection{Das Hamiltonsche Prinzip}	
 Zeigen, dass die Lagrangegleichungen nicht nur aus dem differentiellen Prinzip von d'Alembert folgen: hier momentane virtuelle Verrückungen betrachtet.
 \textbf{Dagegen Hamilton}: \textbf{Integralprinzip}\\
 Variation der gesamten Bahn bei festen Endpunkten
@@ -625,14 +625,14 @@ Wir betrachten Scharen $\vec{q}(t)$ mit gleichen Endpunkten $\vec{q}(t_1)$ und $
 \end{definition*}
 
 
-Beim Hamiltonische Prinzip wird nun die Bahn des Systems betrachtet und wollen eine extremale Bahn finden.
+Beim Hamiltonschen Prinzip wird nun die Bahn des Systems betrachtet und wir wollen eine extremale Bahn finden.
 
 ~\\
-Die Systembewegung erfolgt so, dass $S{\vec{q}(t)}$ für die richtige Trajektorie extremal, d.h. dass die Variation bezüglich der tatsächlichen Bahn verschwindet.
+Die Systembewegung erfolgt so, dass $S{\vec{q}(t)}$ für die richtige Trajektorie extremal wird, d.h. dass die Variation bezüglich der tatsächlichen Bahn verschwindet.
 $$\delta S = \delta \int_{t_1}^{t_2} L(\vec{q}(t), \dotvec{q}(t), t) \d t \overset{!}{=}$$
 
 \begin{bemerkung*}
-	Die Gleichung $\delta S = 0$ enthält auf elegante Weise die gesamte klassische Mechanik. Das Prinzip (der Minimierung der Trajektorie) wird auch jenseits der Mechanik verwendet\footnote{Zum Beispiel in der Teilchenphysik, der geometrischen Optik (Fermatsches Prizip, dabei bewegt sich Licht auf einer Bahn, so dass die benötigte Zeit minimal ist. Damit können Brechungsindeze gefunden werden.)}. Es ist natürlich koordinatenunabhängig.
+	Die Gleichung $\delta S = 0$ enthält auf elegante Weise die gesamte klassische Mechanik. Das Prinzip (der Minimierung der Trajektorie) wird auch jenseits der Mechanik verwendet\footnote{Zum Beispiel in der Teilchenphysik, der geometrischen Optik (Fermatsches Prizip, dabei bewegt sich Licht auf einer Bahn, so dass die benötigte Zeit minimal ist. Damit können Brechungsindizes gefunden werden.)}. Es ist natürlich koordinatenunabhängig.
 \end{bemerkung*}
 
 \subsubsection{Äquivalenz zum Prinzip von d'Alembert}
@@ -649,7 +649,7 @@ $$\delta S = \delta \int_{t_1}^{t_2} L(\vec{q}(t), \dotvec{q}(t), t) \d t \overs
 \Rightarrow \int_{t_1}^{t_2} \sum_{i=1}^N [ \delta (\frac{m_i}{2} \dotvec{r}_i^2 ) + \vec{K}_i \cdot \delta \vec{r}_i ] \d t &= 0
 \intertext{mit $\vec{r}_i = \vec{r}_i(q_1, \dots, q_s, t)$, $i = 1, \dots, N$ findet man die generalisierte (holonom-konservative) Kraft und das Potential}
 \sum_{i=1}^N \vec{K}_i \delta \vec{r}_i = \sum_{j=1}^s Q_j \delta q_j = \sum_{j=1}^{s} - \ffpartial{V}{q_j} \delta q_j &= - \delta V
-\intertext{Daraus folgt dann zusammen genommen, die Äquivalenz des Prinzips von d'Alembert und dem Hamiltonischen}
+\intertext{Daraus folgt dann zusammen genommen, die Äquivalenz des Prinzips von d'Alembert und dem Hamiltonschen}
 0 = \int_{t_1}^{t_2} \delta (T-V) \d t = \delta \int_{t_1}^{t_2} (T-V) \d t = \delta \int_{t_1}^{t_2} L \d t &= 0
 \end{align*}\todo{holonom-konservative Kraft???}
 
@@ -665,18 +665,18 @@ Finden der Kurve $\vec{q}(t)$, die $S\{\vec{q}(t)\}$ extremal macht.
 
 Zunächst ein eindimensionales Problem.
 \paragraph{Problem} Finde eine Kurve $y(x)$ für die ein bestimmtes Funktional extremal wird. Zum Beispiel "`eine kürzeste Verbindung"', beispielsweise auf einer krummen Fläche (Geodäte) wie einer Seifenhaut.
-Die verschiedenen möglichen bilden ein Schar $f(x, y, y')$ von $y(x)$ mit festen Endpunkten. Es wird angenommen, dass $f$ differenzierbar in allen Variablen ist. Im folgenden gilt weiterhin $y' = \ddd{y}{x}$.
+Die verschiedenen möglichen Verbindungen bilden eine Schar $f(x, y, y')$ von $y(x)$ mit festen Endpunkten. Es wird angenommen, dass $f$ differenzierbar in allen Variablen ist. Im folgenden gilt weiterhin $y' = \ddd{y}{x}$.
 Funktional
 \begin{align*}
 J\{y(x)\} &= \int_{x_1}^{x_2} f(x, y, y') \d x = \int_{x_1}^{x_2} \tilde{f}(x) \d x
 \end{align*}
 Das Problem kann nun wie folgt ausgedrückt werden: Für welches $y(x)$ wird $J\{y(x)\}$ extremal?\\
-Dies ist ähnlich zu einer einfachen Extremwertaufgabe, wenn die Schar $y(x)$ durch den Parameter $\alpha$ parametrisiert werden kann. Dies kann zum Beispiel so geschehen so dass
+Dies ist ähnlich zu einer einfachen Extremwertaufgabe, wenn die Schar $y(x)$ durch den Parameter $\alpha$ parametrisiert werden kann. Dies kann zum Beispiel so geschehen, dass
 \begin{align*}
 y_{\alpha = 0}(x) &= y_0(x)
 \intertext{die extremale und damit gesuchte Bahn wird. Damit kann man jetzt $y_\alpha$ aufteilen}
 y_\alpha(x) &= y_0(x) + \gamma_\alpha(x)
-\intertext{$\gamma_\alpha(x)$ ist hierbei eine fast beliebige, differenzierbare Funktion mit, welche an den Endpunkten für alle $\alpha$ verschwindet, also 0 wird. Nach dem, wie $\gamma_\alpha$ konstruiert wurde gilt auch}
+\intertext{$\gamma_\alpha(x)$ ist hierbei eine fast beliebige, differenzierbare Funktion, welche an den Endpunkten für alle $\alpha$ verschwindet, also 0 wird. Nach dem, wie $\gamma_\alpha$ konstruiert wurde gilt auch}
 \gamma_{\alpha = 0}(x) &= 0~~~\forall x
 \intertext{Man kann $\gamma_\alpha$ auch anders angeben: $\gamma_\alpha(x) = \alpha \eta(x), ~~~ \eta(x_1) = \eta(x_2) = 0$. $x$ wird festgehalten und dann eine Taylorreihe mit $\alpha = 0$ wie folgt entwickelt}
 \gamma_\alpha(x) &= \alpha (\ffpartial{\gamma_\alpha(x)}{\alpha})_{\alpha = 0} + \frac{\alpha^2}{2} (\frac{\partial^2 \gamma_\alpha(x)}{\partial x^2})_{\alpha = 0} + \dots
@@ -704,7 +704,7 @@ $$\ffpartial{f}{y} - \dd x \ffpartial{f}{y'} = 0$$
 Und damit eine Differentialgleichung 2. Ordnung für das gesuchte $y(x)$. (vgl. Lagrange-Gleichung 2. Art)
 
 \begin{beispiel*}[Kürzeste Verbindung zweier Punkte in der Ebene]~\\
-	Welches Funktional? (Infitisemale Länge $\d s = \sqrt{\d x^2 \d y^2}$) Gesucht ist $\int_{p_1}^{p_2} \d s = J$\\
+	Welches Funktional? (Infinitesimale Länge $\d s = \sqrt{\d x^2 \d y^2}$) Gesucht ist $\int_{p_1}^{p_2} \d s = J$\\
 	$$J = \int_{p_1}^{p_2} \d s = \int_{x_1}^{x_2} \sqrt{\d x^2 + \d y^2} = \int_{x_1}^{y_2} \sqrt{1 + (\ddd{y}{x})^2} \d x = \int_{x_1}^{x_2} \sqrt{1 + {y'}^2} \d x$$
 	$\delta J = 0$ führt zur extremalen Bahn $y(x)$. 
 	$$ f(x, y, y') = \sqrt{1 + {y'}^2}$$
@@ -720,7 +720,7 @@ Und damit eine Differentialgleichung 2. Ordnung für das gesuchte $y(x)$. (vgl. 
 \end{beispiel*}
 
 \begin{beispiel*}[Minimale Rotationsfläche]~\\
-\textit{Es wird im Grunde genommen wie beim letzten Beispiel vorgeganen} Die Minimalfläche ist
+\textit{Es wird im Grunde genommen wie beim letzten Beispiel vorgegangen} Die Minimalfläche ist
 \begin{align*}
 J &= \int \d A = \int 2 \pi x \d s
 \intertext{mit $\d s = \sqrt{\d x^2 + \d y^2} = \sqrt{1 + (\ddd{y}{x})^2} \d x = \sqrt{1 + {y'}^2} \d x$ folgt}
@@ -737,14 +737,14 @@ f(x,y,y') &= x \sqrt{1 + {y'}^2} & \text{~\textit{mit }}y' = \ddd{y}{x}\\
 y(x) &= a \text{arcosh}(\frac{x}{a}) + b & \text{~\textit{oder }} x(y) = a \cosh (\frac{y - b}{a})
 \end{align*}
 $a$, $b$ können mit den Anfangsbedingungen gefunden werden $(x_1, y_1)$ und $(x_2, y_2)$.\\
-Ein Hinweis am Rande: Die Kurve, welche durch den Kosinushyperbolikus beschrieben wird, wird auch Kettenlinie\footnote{\href{https://de.wikipedia.org/wiki/Kettenlinie_\%28Mathematik\%29}{Wikipedia}} genannt.
+Ein Hinweis am Rande: Die Kurve, welche durch den Kosinus Hyperbolicus beschrieben wird, wird auch Kettenlinie\footnote{\href{https://de.wikipedia.org/wiki/Kettenlinie_\%28Mathematik\%29}{Wikipedia}} genannt.
 \end{beispiel*}
 
 \subsubsection{Verallgemeinerung des Variationsproblems auf mehrere Variablen}
 \textit{\dots und damit die Eulergleichung natürlich auch.}\\
 Das betrachtete $y$ wird nun als Vektor $\vec{y}(x) = (y_1(x), \dots, y_s(x))$ geschrieben und ganz analog
 $$\delta J = \int_{x_1}^{x_2} \d x \sum_{i=1}^{s} (\ffpartial{f}{y_i} - \dd x \ffpartial{f}{y'_i}) \delta y_i = 0$$
-Hierbei sind $\delta y_i$ die unabhängigen Freiheitsgrade offensichtlich gibt es eine Gleichung pro Freiheitsgrad
+Hierbei sind $\delta y_i$ die unabhängigen Freiheitsgrade. Offensichtlich gibt es eine Gleichung pro Freiheitsgrad
 \begin{align*}
 \ffpartial{f}{y_i} - \dd x \ffpartial{f}{y'_i} &= 0, i = 1, \dots, s
 \intertext{Dies stellt in etwa die Euler-Langrange-Gleichungen dar. Nun kann man das Hamiltonische Prinzip anwenden}
@@ -752,13 +752,13 @@ Hierbei sind $\delta y_i$ die unabhängigen Freiheitsgrade offensichtlich gibt e
 \intertext{Es funktioniert also völlig analog, damit bekommt man Langrangegleichungen 2. Art}
 \dd t \ffpartial{L}{\dot{q}_i} - \ffpartial{L}{q_i} &= 0
 \end{align*}
-\conseq \textbf{Hamiltonisches Prinzip}
+\conseq \textbf{Hamiltonsches Prinzip}
 Das Integralprinzip (Hamilton) und das differentielle Prinzip (d'Alembert) sind äquivalent. Beide führen auf die Lagrangegleichungen. 
 
 \textit{Das Hamiltonsche Prinzip wird ausgiebig in der Quantenmechanik verwendet. Im folgenden wird weiter auf die Hamiltonfunktion eingegangen um als Ziel sich in die Quantenmechanik zu bewegen. Es werden im speziellen Eigenschaften der Hamilton-Funktion angegeben.}
 
 \subsubsection{Erhaltungsgrößen}
-\paragraph{Allgemeines System} Die allgemeinen Koordinaten $q_i$, $\dot{q}_i$ für $i = 1, \dots, s$ sind im Laufe der Zeit veränderlich, womit es $2S$ Funktionen der Zeit gibt. Einige von diesen sind jedoch konstant\footnote{Mathematisch ausgedrückt gilt dann $F_r = F_r(q_1, \dots, q_s, \dot{q}_1, \dot{q}_s, t) = \text{konstant}$.}, was nicht Zufall sein muss.\footnote{Es ist aus offensichtlichen das Ziel, dass möglichst viele Funktionen konstant sind. Denn wie man schon im Lagrange-Teil gesehen hat, wird damit die Komplexität des Problems reduziert.}
+\paragraph{Allgemeines System} Die allgemeinen Koordinaten $q_i$, $\dot{q}_i$ für $i = 1, \dots, s$ sind im Laufe der Zeit veränderlich, womit es $2S$ Funktionen der Zeit gibt. Einige von diesen sind jedoch konstant\footnote{Mathematisch ausgedrückt gilt dann $F_r = F_r(q_1, \dots, q_s, \dot{q}_1, \dot{q}_s, t) = \text{konstant}$.}, was nicht Zufall sein muss.\footnote{Es ist aus offensichtlichen Gründen das Ziel, dass möglichst viele Funktionen konstant sind. Denn wie man schon im Lagrange-Teil gesehen hat, wird damit die Komplexität des Problems reduziert.}
 Diese konstanten Funktionen heißen auch \textbf{Integrale der Bewegung}.
 
 \paragraph{Im Prinzip gilt} Bei $2S$ Integralen der Bewegung $C_i$ ist das Problem gelöst, weil $q_i = q_i(C_1, \dots, C_{2S}, t)$ und damit das Problem nicht mehr dynamisch ist. Die Lösung kann dann einfach abgelesen werden.
@@ -769,18 +769,18 @@ Allgemein gilt, dass, wie schon gesagt, möglichst viele Konstanten der Bewegung
 $$p_j = \ffpartial{L}{\dot{q}_j} = \text{konstant}$$
 Ein gutes Beispiel hierfür sind Zweikörperprobleme.
 
-\begin{beispiel*}[Zweikörperproblem\footnote{\href{http://de.wikipedia.org/wiki/Zweik\%C3\%B6rperproblem}{Wikipedia}}\footnote{Konkrete Beispiele: Anziehung zwischen Protonen und Elektronen im Atom oder der Sonne und der Erde.}]~\\
+\begin{beispiel*}[Zweikörperproblem\footnote{\href{http://de.wikipedia.org/wiki/Zweik\%C3\%B6rperproblem}{Wikipedia}}\footnote{Konkrete Beispiele: Anziehung zwischen Protonen und Elektronen im Atom, oder zwischen Sonne und Erde.}]~\\
 Zwei Massepunkte $m_1$ und $m_2$ haben die Koordinaten $\vec{r}_1$ und $\vec{r}_2$ und die Relativkoordinate $\vec{r} = \vec{r}_i - \vec{r}_2$. Als Kraft herrscht nur das Potentialfeld\footnote{Nur abhängig von der relativen Position der Massepunkte. Beispiele hierfür sind das Gravitationsfeld oder das elektrische Feld}
 \begin{align*}
 V(\vec{r}_1, \vec{r}_2) &= V(| \vec{r}_1 - \vec{r}_2|) = V(r)\\
-\text{Gesammtmasse~~~} M &= m_1 + m_2\\
+\text{Gesamtmasse~~~} M &= m_1 + m_2\\
 \text{reduzierte Masse~~~} \mu &= \frac{m_1 m_2}{m_1 + m_2}\\
 \text{Schwerpunkt~~~} R &= \frac{1}{M} (m_1 \vec{r}_1 + m_2 \vec{r}_2)\\
 \text{Relativkoordinate~~~} \vec{r} &= \vec{r}_1 - \vec{r}_2 = r (\sin \vartheta \cos \varphi, \sin \vartheta \sin \varphi, \cos \vartheta)
 \end{align*}
 
 \paragraph{Wir Erwarten}
-\dots das sowohl Bewegung des Schwerpunkts trivial also gleichförmig, wie auch  Bewegung der reduzierten Masse $\mu$ im Schwerpunktsystem ist.\\~\\
+\dots das sowohl die Bewegung des Schwerpunkts trivial, also gleichförmig, wie auch die Bewegung der reduzierten Masse $\mu$ im Schwerpunktsystem ist.\\~\\
 Die generalisierten Koordinaten sind in unserem Beispiel
 \begin{align*}
 \vec{R} &= (q_1, q_2, q_3) \text{~mit~} r = q_4, \vartheta = q_5, \varphi = q_6
@@ -790,7 +790,7 @@ Die generalisierten Koordinaten sind in unserem Beispiel
 	\vec{p} &= M \dotvec{R} = \text{konstant}\\
 	p_6 &= \ffpartial{L}{\dot{q}_6} = \mu q_4^2 \dot{q}_6 \sin^2 q_5 = \mu \dot{\varphi} r^2 \sin^2 \vartheta = L_r^{(Z)} = \text{konstant}\\
 	\intertext{Die $z$-Komponente des Relativdrehimpulses ist ersichtlicherweise konstant\footnote{Vergleiche: Geworfenes Frisbee, dessen Drehachse relativ gesehen sich nicht verändert.\footnote{Tipp: Dies mit einer Tafelkreide zu probieren ist aufgrund des vergleichsweise geringen Impulses schlecht möglich.}}}
-	\intertext{Wenn man das Problem nun versucht in den Kartesischen Koordinaten anzugehen, führt das folgender Langrange-Funktion}
+	\intertext{Wenn man das Problem nun versucht in den kartesischen Koordinaten anzugehen, führt das zu folgender Langrange-Funktion}
 	L &= \frac{m_1}{2} (\dot{x}_1^2 + \dot{y}_1^2 + \dot{z}_1^2) + \frac12 m_2 (\dot{x}_2^2 + \dot{y}_2^2 + \dot{z}_2^2) \\
 	~&- V((x_1 - x_2)^2 + (y_1 - y_2)^2 + (z_1 - z_2)^2)
 	\intertext{Auch hier sind die Erhaltungssätze ebenso gültig. Sie sind aber viel schwerer abzulesen.}

--- a/document.tex
+++ b/document.tex
@@ -119,7 +119,7 @@
 
 \paragraph{Aber:} Experimente zeigten im Laufe der Zeit immer mehr Widersprüche zur klassischen Physik. Im Folgenden werden ein paar von ihnen angegeben:
 \begin{description}
-	\item[Michelson-Morley] Es wurde gezeigt, dass es keinen "`kein Äther"' gibt, durch den sich das Licht bewegt und dass die Lichtgeschwindigkeit konstant ist.
+	\item[Michelson-Morley] Es wurde gezeigt, dass es keinen "`Äther"' gibt, durch den sich das Licht bewegt und dass die Lichtgeschwindigkeit konstant ist.
 	\item[\conseq] \textbf{Spezielle Relativitätstheorie} auf die in einem späteren Kapitel noch eingegangen wird.
 	\item[Diskrete Emmisionsspektren (Spektrallinien)] sind bei Strahlung emmitierenden Objekten messbar.
 	\item[Welleneigenschaft von Teilchen] vgl. die Spaltexperimente mit Elektronen \footnote{Aufbau: Elektronen werden auf einen Doppelspalt "`geschossen"'. Dahinter befindet sich in einiger Entfernung ein Detektor. Klassisch würde man erwarten, dass ein Elektron ein Teilchen ist und damit der Detektor nur auf zwei schmalen Streifen Elektronen detektiert. Im Experiment detektiert man dagegen ein Interferenzmuster, dass an Wellen erinnert. Vgl. \href{http://de.wikipedia.org/wiki/Doppelspaltexperiment}{Wikipedia}} \conseq Widerspruch zur klassischen Physik, denn es sind nur die Wahrscheinlichkeiten vorhersagbar mit der sich ein Elektron zu einem bestimmten Zeitpunkt an einem bestimmten Ort befindet.
@@ -133,7 +133,7 @@ Das nächste Kapitel behandelt die klassische Mechanik (ein Teilgebiet der klass
 
 \section{Abriss der Newtonsche Mechanik}
 \paragraph{Problemstellung der Mechanik}
-Für ein System von $N$ Massepunkten $m_i$ sind die jeweiligen Orte $\vec{r}_i$ und Geschwindigkeiten $\vec{v}_i$ zur Zeit $t_0$ gegeben. Es wirken die äußeren Kräfte $\vec{F}_i$ auf die Teilchen und die Kräfte $\vec{F}_{ij}$ zwischen den Teilchen $i$ und $j$. Wie lauten nun die \textbf{kinematischen Größen} $\vec{r}_i, \vec{v}_i = \dotvec{r}_i(t)$  für beliebige Zeiten $t$ unter diesem Voraussetzungen? Die kinematischen Größen $\vec{r}_i(t)$, $\dotvec{r}_i(t)$ und $\ddotvec{r}_i(t)$ werden als Lösungen ordentlicher/gewöhnlicher \Dgl gefunden \textendash~ auch  \textbf{Bewegungsgleichungen} genannt.\\
+Für ein System von $N$ Massepunkten $m_i$ sind die jeweiligen Orte $\vec{r}_i$ und Geschwindigkeiten $\vec{v}_i$ zur Zeit $t_0$ gegeben. Es wirken die äußeren Kräfte $\vec{F}_i$ auf die Teilchen und die Kräfte $\vec{F}_{ij}$ zwischen den Teilchen $i$ und $j$. Wie lauten nun die \textbf{kinematischen Größen} $\vec{r}_i, \vec{v}_i = \dotvec{r}_i(t)$  für beliebige Zeiten $t$ unter diesen Voraussetzungen? Die kinematischen Größen $\vec{r}_i(t)$, $\dotvec{r}_i(t)$ und $\ddotvec{r}_i(t)$ werden als Lösungen ordentlicher/gewöhnlicher Differentialgleichungen gefunden \textendash~ auch  \textbf{Bewegungsgleichungen} genannt.\\
 
 \begin{definition*}[Kraft]
 Eine Kraft ist eine vektorielle, also richtungsbehaftete, Größe $\vec{F}$ welche die Ursache einer Bewegung ist, d.h. sie bewirkt die Änderung des Bewegungszustandes eines Teilchens.
@@ -154,7 +154,7 @@ Es gibt \textbf{Inertialsysteme} in welchen ein kräftefreier Körper ruht oder 
 	\end{equation*}
 \end{definition*}
 
-\begin{definition*}[2. Gesetz \textit{Newtonsches Bewegungssgesetz}]
+\begin{definition*}[2. Gesetz \textit{Newtonsches Bewegungsgesetz}]
 \begin{equation*}
 	\dot{\vec{p}} = \vec{F}, \dot{\vec{v}} = \vec{a} \rightarrow \vec{F} = m \vec{a}
 \end{equation*}
@@ -173,7 +173,7 @@ Die Definition der trägen Masse ist damit unabhängig von der Kraft. Hierfür e
 Die Anziehung zwischen zwei Körpern der Masse $M$ und $m$ ist 
 $$\vec{F}_G = \gamma \frac{M m}{r^2} \hat{r}$$
  wobei $\hat{r} = \frac{\vec{r}}{|\vec{r}|}$ und $\gamma$ die Newtonsche Gravitationskonstante sind. Sofern der Abstand und eine der Massen, ohne Beschränkung der Allgemeinheit $M$, konstant ist, kann man die Formel zu $F = m g$ vereinfachen. $g$ ist auf der Erde $\approx 9.81 \frac{\text{m}}{\text{s}^2}$.
- Als Folge daraus sind träge und die schwere Masse eines Teilchens identisch.
+ Als Folge daraus sind die träge und die schwere Masse eines Teilchens identisch.
 \end{beispiel*}
 
 \begin{beispiel*}[Coulombkraft]
@@ -210,14 +210,14 @@ Die Newtonsche Gesetze sind, wie schon angemerkt, unter Transformationen dieser 
 \end{definition*}
 
 \begin{definition*}[Nichtinertialsysteme]
-	Nichtinertialsysteme sind zum Beispiel \textit{Beschleunigte Bezugssysteme}. Die Koordinaten werden in solchen Systemen nicht gleichförmig gegeneinander verschoben. Hierdurch kommt es zu \textbf{Scheinkräften}. Ein konkretes Beispiel hierfür ist die Corioliskraft, deren Wirkung durch das sogenannte \href{https://de.wikipedia.org/wiki/Foucaultsches_Pendel}{Foucaultsche Pendel}\footnote{Ein langes Pendel, welches langsam die Richtung ändert, weil sich die Erde unter ihm "`wegbewegt"'.}. Ein weiteres Beispiel ist die Zentripetalkraft\footnote{Die \href{http://de.wikipedia.org/wiki/Zentripetalkraft}{Zentripetalkraft} ist die Kraft, die einen Körper zum Mittelpunkt seiner Kreisbahn hinzieht. Natürlich nur, sofern er sich auf einer solchen bewegt.}.
+	Nichtinertialsysteme sind zum Beispiel \textit{Beschleunigte Bezugssysteme}. Die Koordinaten werden in solchen Systemen nicht gleichförmig gegeneinander verschoben. Hierdurch kommt es zu \textbf{Scheinkräften}. Ein konkretes Beispiel hierfür ist die Corioliskraft, deren Wirkung durch das sogenannte \href{https://de.wikipedia.org/wiki/Foucaultsches_Pendel}{Foucaultsche Pendel}\footnote{Ein langes Pendel, welches langsam die Richtung ändert, weil sich die Erde unter ihm "`wegbewegt"'.} gezeigt werden kann. Ein weiteres Beispiel ist die Zentripetalkraft\footnote{Die \href{http://de.wikipedia.org/wiki/Zentripetalkraft}{Zentripetalkraft} ist die Kraft, die einen Körper zum Mittelpunkt seiner Kreisbahn hinzieht. Natürlich nur, sofern er sich auf einer solchen bewegt.}.
 \end{definition*}
 
 
 \subsection{Weitere spezielle Themen}
 Im folgenden ein paar Themen, welche nicht direkt in der Vorlesung behandelt werden (wohl aber in Teilen in der Übung), aber trotzdem wichtig sind.
 \begin{itemize}
-	\item Schwingungen, z.B. gedämpte oder erzwungene
+	\item Schwingungen, z.B. gedämpfte oder erzwungene
 	\item Mehrere Massepunkte (zum Beispiel durch Federn gekoppelt \conseq Eigenschwingungen) 
 	\item Viel mehr Massepunkte \conseq starre Körper, Bewegung $+$ Rotation \conseq Kreiselbewegung
 \end{itemize}

--- a/document.tex
+++ b/document.tex
@@ -123,10 +123,10 @@
 \begin{description}
 	\item[Michelson-Morley] Es wurde gezeigt, dass es keinen "`Äther"' gibt, durch den sich das Licht bewegt und dass die Lichtgeschwindigkeit konstant ist.
 	\item[\conseq] \textbf{Spezielle Relativitätstheorie} auf die in einem späteren Kapitel noch eingegangen wird.
-	\item[Diskrete Emmisionsspektren (Spektrallinien)] sind bei Strahlung emittierenden Objekten messbar.
+	\item[Diskrete Emissionsspektren (Spektrallinien)] sind bei Strahlung emittierenden Objekten messbar.
 	\item[Welleneigenschaft von Teilchen] vgl. die Spaltexperimente mit Elektronen \footnote{Aufbau: Elektronen werden auf einen Doppelspalt "`geschossen"'. Dahinter befindet sich in einiger Entfernung ein Detektor. Klassisch würde man erwarten, dass ein Elektron ein Teilchen ist und damit der Detektor nur auf zwei schmalen Streifen Elektronen detektiert. Im Experiment detektiert man dagegen ein Interferenzmuster, dass an Wellen erinnert. Vgl. \href{http://de.wikipedia.org/wiki/Doppelspaltexperiment}{Wikipedia}} \conseq Widerspruch zur klassischen Physik, denn es sind nur die Wahrscheinlichkeiten vorhersagbar mit der sich ein Elektron zu einem bestimmten Zeitpunkt an einem bestimmten Ort befindet.
 	\item[Teilcheneigenschaften von Lichtwellen] vgl. \href{http://de.wikipedia.org/wiki/Photoelektrischer_Effekt}{Photoelektrischer-Effekt}
-	\item[Schwarzkörperspektrum] Abhängigkeit des emittierten Lichtspektrums eines Körpers/Gases von des Temperatur. Das (rein gedankliche) Schwarzkörperspektrum widerspricht der Boltzmann-Verteilung. Daraus folgerte Plank, dass die untersuchten Teilchen (des Gases oder Körpers) ununterscheidbar oder identisch sind.
+	\item[Schwarzkörperspektrum] Abhängigkeit des emittierten Lichtspektrums eines Körpers/Gases von des Temperatur. Das (rein gedankliche) Schwarzkörperspektrum widerspricht der Boltzmann-Verteilung. Daraus folgerte Planck, dass die untersuchten Teilchen (des Gases oder Körpers) ununterscheidbar oder identisch sind.
 	\item[\conseq] \textbf{Quantenphysik} auf die in einem späteren Kapitel noch eingegangen wird.
 \end{description}
 Das nächste Kapitel behandelt die klassische Mechanik (ein Teilgebiet der klassischen Physik), da diese notwendig zum Verständnis der modernen Physik ist.
@@ -142,7 +142,7 @@ Eine Kraft ist eine vektorielle, also richtungsbehaftete, Größe $\vec{F}$ welc
 \end{definition*}
 
 \subsection{Newtonsche Gesetze}
-\begin{definition*}[1. Gesetz \textit{Galileiisches Trägheitsgesetz}] 
+\begin{definition*}[1. Gesetz \textit{Galileisches Trägheitsgesetz}] 
 Es gibt \textbf{Inertialsysteme} in welchen ein kräftefreier Körper ruht oder sich geradlinig und gleichförmig bewegt.
 \end{definition*}
 
@@ -178,8 +178,8 @@ $$\vec{F}_G = \gamma \frac{M m}{r^2} \hat{r}$$
  Als Folge daraus sind die träge und die schwere Masse eines Teilchens identisch.
 \end{beispiel*}
 
-\begin{beispiel*}[Coulombkraft]
-Die Coulombkraft ist die Kraft zwischen zwei elektrischen Ladungen $Q_1$ und $Q_2$:
+\begin{beispiel*}[Coulomb-Kraft]
+Die Coulomb-Kraft ist die Kraft zwischen zwei elektrischen Ladungen $Q_1$ und $Q_2$:
 \begin{equation*}
 	\vec{F} = \frac{1}{4 \pi \epsilon_0} \frac{Q_1 Q_2}{r^2} \hat{r}
 \end{equation*}
@@ -407,25 +407,25 @@ $$\forall j:  \dd t ( \ffpartial{T}{\dot{q}_j}) - \ffpartial{T}{q_j} - Q_j = 0$$
 In einem konservativen System ist die Kraft $Q_j$ auf ein Potential $V_j$ zurückzuführen. Das Potential V, und damit auch die generalisierte Kraft $Q_j = - \ffpartial{V}{q_j}$, ist unabhängig von der Geschwindigkeit $\dot{q}_j$. Anders ausgedrückt gilt
 $$\ffpartial{V}{\dot q_j} = 0 \text{~ und damit ~} \sum_{j=1}^s \left(  \dd{t} \fpartial{\dot{q}_j} (T-V) - \fpartial{q_j} (T -V) \right) \delta q_j = 0$$
 
-\subsubsection{Langangefunktion}
-Man kann die Gleichungen auch wie folgt schreiben, wenn man die Lagrangefunktion $L$ einführt.
+\subsubsection{Lagrange-Funktion}
+Man kann die Gleichungen auch wie folgt schreiben, wenn man die Lagrange-Funktion $L$ einführt.
 $$L(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t) = T(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t) - V(q_1, \dots, q_s, t)$$
 
-\subsubsection{Lagrangegleichung \textit{1. Art}}
+\subsubsection{Lagrange-Gleichung \textit{1. Art}}
 $$\sum_{j = 1}^s  (  \dd{t} \ffpartial{L}{\dot{q}_j} - \ffpartial{L}{q_j}  ) \delta q_j = 0$$
 
-\subsubsection{Lagrangegleichung \textit{2. Art}}
+\subsubsection{Lagrange-Gleichung \textit{2. Art}}
 Gegeben sei wieder ein konservatives System mit holonomen Zwangsbedingungen.
 $$ \dd{t} \ffpartial{L}{\dot{q}_j} - \ffpartial{L}{q_j} = 0 \text{~für~} j= 1, \dots, s$$
 
 \begin{bemerkung*}[Fazit]~\\
-	Mit den Lagrangegleichungen wurden die Zwangskräfte eliminiert. Man hat dafür $S$ gewöhnliche Differenzialgleichungen 2. Ordnung bekommen, für welche man $2S$ Anfangsbedingungen benötigt um sie zu lösen.
+	Mit den Lagrange-Gleichungen wurden die Zwangskräfte eliminiert. Man hat dafür $S$ gewöhnliche Differenzialgleichungen 2. Ordnung bekommen, für welche man $2S$ Anfangsbedingungen benötigt um sie zu lösen.
 	Statt Impuls und Kraft, wie bei den Newtonschen Gesetzen, liegen hierbei Energie und Arbeit im Fokus.
 \end{bemerkung*}
 
 \begin{bemerkung*}[Ausblick]
 	$$L = L(\vardots{q}{s}, \vardots{\dot{q}}{s}, t)$$
-	Die Lagrangegleichungen sind invariant gegenüber Punkttransformationen \\
+	Die Lagrange-Gleichungen sind invariant gegenüber Punkttransformationen \\
 	$(\vardots{q}{s}) \underset{\text{differenzierbar}}{\leftrightarrow} (\vardots{\bar{q}}{s})$ mit $\bar{q}_i = \bar{q}_i(\vardots{q}{s}, t)$, $q_i = q_i(\vardots{\bar{q}}{s}, t)$
 	Damit hat man bei der Wahl der generalisierten Koordinaten gewisse Freiheiten. Diese kann man zur Vereinfachung des Problems nutzen. Hierbei ist es sinnvoll weitere Symmetrien im Problem auszunutzen.
 \end{bemerkung*}
@@ -525,12 +525,12 @@ Für die häufigsten Fälle mit \textbf{holonomen} Zwangsbedingungen und \textbf
 \begin{enumerate}
 \item Zwangsbedingungen formulieren
 \item Generalisierte Koordinaten festlegen
-\item Lagrangefunktion hinschreiben (mit generalisierten Koordinaten und Geschwindigkeiten)
-\item Lagrangefunktion ableiten und wenn möglich lösen
+\item Lagrange-Funktion hinschreiben (mit generalisierten Koordinaten und Geschwindigkeiten)
+\item Lagrange-Funktion ableiten und wenn möglich lösen
 \item Eventuell Rücktransformation auf gewöhnliche Koordinaten
 \end{enumerate}
 
-\subsubsection{Nichtholonome Systeme}
+\subsubsection{Nicht-holonome Systeme}
 Bei holonomen Systemen gibt es $S = 3N - p$ unabhängige generalisierte Koordinaten. Diese sind bei nicht-holonomen Systemen nicht mehr unabhängig.
 
 Falls die nicht-holonomen Zwangsbedingungen in differentieller Form vorliegen (also als Differentialgleichung) gibt es ein Lösungsverfahren über die Methode der sogenannten Lagrange-Multiplikatoren, welche im folgenden erläutert werden.
@@ -555,7 +555,7 @@ Damit gilt für nicht-holonome Bedingungen in $q_j$
 \intertext{Nur ein Teil der generalisierten Koordinaten ist, wie schon oft erwähnt, unabhängig voneinander: $m=1,\dots,j-p$ sind unabhängig und $m = j-p+1, \dots j$ sind abhängig, die Wahl der $q_m$ findet dementsprechend statt}
 \intertext{Wähle für die letzten $p$ Gleichungen die bisher nicht bestimmten $\lambda_i$ so, dass}
 \ffpartial{L}{q_m} - \dd t \ffpartial{L}{\dot{q}_m} + \sum_{i=1}^p \lambda_i a_{im} &= 0, m = j-p+1, \dots, j
-\intertext{Damit hat man nur noch Gleichungen mit unabhängigen $q_m$ \conseq jeder Summand ist 0. Woraus Lagrangegleichungen 1. Art entstehen}
+\intertext{Damit hat man nur noch Gleichungen mit unabhängigen $q_m$ \conseq jeder Summand ist 0. Woraus Lagrange-Gleichungen 1. Art entstehen}
 \dd t \ffpartial{L}{\dot{q}_m} - \ffpartial{L}{q_m} &= \sum_{i=1}^p \lambda_i a_{im}, m = 1, \dots, j
 \intertext{Hierbei gilt noch $\sum_{m=1}^j a_{im} \dot{q}_m + b_{it} = 0$. Damit hat man $j + p$ Gleichungen für $j$ generalisierte Koordinaten und $p$ Multiplikatoren $\lambda_i$.}
 \end{align*}
@@ -571,7 +571,7 @@ und damit
 \begin{align*}
 	a_{im} = \ffpartial{\bar{f}_i}{q_m}& &b_{it} = \ffpartial{\bar{f}_i}{t}
 \end{align*}
-Die Zwangskräfte in holonomen Systemen können nun mit Lagrangegleichungen 1. Art bestimmt werden.
+Die Zwangskräfte in holonomen Systemen können nun mit Lagrange-Gleichungen 1. Art bestimmt werden.
 
 \begin{beispiel*}[holonome Zwangsbedingungen mit Zwangskräften]
 Es wird ein Pendel mit Winkel $\varphi$ zum Lot, der Länge $l$ und der Masse $m$ betrachtet.
@@ -609,12 +609,12 @@ $$\varphi(t) = \varphi_0 \sin \sqrt{\frac{g}{l}} t$$
 \end{beispiel*}
 
 \subsection{Das Hamiltonsche Prinzip}	
-Zeigen, dass die Lagrangegleichungen nicht nur aus dem differentiellen Prinzip von d'Alembert folgen: hier momentane virtuelle Verrückungen betrachtet.
+Zeigen, dass die Lagrange-Gleichungen nicht nur aus dem differentiellen Prinzip von d'Alembert folgen: hier momentane virtuelle Verrückungen betrachtet.
 \textbf{Dagegen Hamilton}: \textbf{Integralprinzip}\\
 Variation der gesamten Bahn bei festen Endpunkten
 Dazu Bahnen $\vec{q}(t)$ im Konfigurationsraum
 $$\vec{q}(t) = (q_1(t), \dots, q_s(t))$$
-ein $\vec{q}(t)$ beschreibt einen Zustand des gesamten Systems. Für gegebene $\vec{q}(t)$ und $\dot{\vec{q}}(t)$ wird die Lagrangefunktion Funktion der Zeit 
+ein $\vec{q}(t)$ beschreibt einen Zustand des gesamten Systems. Für gegebene $\vec{q}(t)$ und $\dot{\vec{q}}(t)$ wird die Lagrange-Funktion Funktion der Zeit 
 $$L(\vec{q}(t), \dotvec{q}(t), t) = \tilde{L}(t)$$
 
 \begin{definition*}[Wirkungsintegral]
@@ -634,7 +634,7 @@ Die Systembewegung erfolgt so, dass $S\{\vec{q}(t)\}$ für die richtige Trajekto
 $$\delta S = \delta \int_{t_1}^{t_2} L(\vec{q}(t), \dotvec{q}(t), t) \d t \overset{!}{=} 0$$
 
 \begin{bemerkung*}
-	Die Gleichung $\delta S = 0$ enthält auf elegante Weise die gesamte klassische Mechanik. Das Prinzip (der Minimierung der Trajektorie) wird auch jenseits der Mechanik verwendet\footnote{Zum Beispiel in der Teilchenphysik, der geometrischen Optik (Fermatsches Prizip, dabei bewegt sich Licht auf einer Bahn, so dass die benötigte Zeit minimal ist. Damit können Brechungsindizes gefunden werden.)}. Es ist natürlich koordinatenunabhängig.
+	Die Gleichung $\delta S = 0$ enthält auf elegante Weise die gesamte klassische Mechanik. Das Prinzip (der Minimierung der Trajektorie) wird auch jenseits der Mechanik verwendet\footnote{Zum Beispiel in der Teilchenphysik, der geometrischen Optik (Fermatsches Prinzip, dabei bewegt sich Licht auf einer Bahn, so dass die benötigte Zeit minimal ist. Damit können Brechungsindizes gefunden werden.)}. Es ist natürlich koordinatenunabhängig.
 \end{bemerkung*}
 
 \subsubsection{Äquivalenz zum Prinzip von d'Alembert}
@@ -660,8 +660,8 @@ Finden der Kurve $\vec{q}(t)$, die $S\{\vec{q}(t)\}$ extremal macht.
 
 \subsubsection{Elemente der Variationsrechnung}
 
-\begin{definition*}[Eulergleichung]
-	Wie die Lagrangegleichung, gilt aber ganz allgemein für Variationsprobleme.
+\begin{definition*}[Euler-Gleichung]
+	Wie die Lagrange-Gleichung, gilt aber ganz allgemein für Variationsprobleme.
 	$$ \ffpartial{f}{y} - \dd x \ffpartial{f}{y'} = 0$$
 \end{definition*}
 
@@ -686,7 +686,7 @@ y_\alpha(x) &= y_0(x) + \gamma_\alpha(x)
 \gamma_\alpha(x) &= y_0(x) + \alpha(\ffpartial{y_\alpha}{\alpha})_{\alpha = 0} + \dots
 \end{align*}
 
-$y_\alpha(x)$ wird nun in der Nähe (besser gesagt in der $\epsilon$-Umgebung) von $\alpha = 0$ variert. Daraus folgt, dass $\alpha \rightarrow \d \alpha$.
+$y_\alpha(x)$ wird nun in der Nähe (besser gesagt in der $\epsilon$-Umgebung) von $\alpha = 0$ variiert. Daraus folgt, dass $\alpha \rightarrow \d \alpha$.
 Und damit $\delta y = y_{\d \alpha} - y_0(x) = \d \alpha (\ffpartial{y_\alpha(x)}{\alpha})_{\alpha = 0}$.
 Wird nun $\delta y$ bei festem $x$ betrachtet (vgl. virtuelle Verrückungen bei fester Zeit t. ($\delta t = 0$)) kommt man zu einer Variation des Funktionals $J\{y(x)\}$
 \begin{align*}
@@ -713,7 +713,7 @@ Und damit eine Differentialgleichung 2. Ordnung für das gesuchte $y(x)$. (vgl. 
 	$$J = \int_{p_1}^{p_2} \d s = \int_{x_1}^{x_2} \sqrt{\d x^2 + \d y^2} = \int_{x_1}^{x_2} \sqrt{1 + (\ddd{y}{x})^2} \d x = \int_{x_1}^{x_2} \sqrt{1 + {y'}^2} \d x$$
 	$\delta J = 0$ führt zur extremalen Bahn $y(x)$. 
 	$$ f(x, y, y') = \sqrt{1 + {y'}^2}$$
-	Nun verwenden wir die Eulergleichung: $\ffpartial{f}{y} = 0$; $\ffpartial{f}{y'} = \frac{y'}{\sqrt{1 + {y'}^2}}$ und damit folgt
+	Nun verwenden wir die Euler-Gleichung: $\ffpartial{f}{y} = 0$; $\ffpartial{f}{y'} = \frac{y'}{\sqrt{1 + {y'}^2}}$ und damit folgt
 	$$\dd x \frac{y'}{\sqrt{1 + {y'}^2}} = 0$$
 	oder anders gesagt
 	$$\frac{y'}{\sqrt{1 + {y'}^2}} = \text{konstant} = c \rightarrow {y'}^2 = c^2 ( 1 + {y'}^2)$$
@@ -721,7 +721,7 @@ Und damit eine Differentialgleichung 2. Ordnung für das gesuchte $y(x)$. (vgl. 
 	$${y'}^2 = \text{konstant}, y' = \text{konstant}$$
 	und damit schlussendlich die Lösung des Problems
 	$$y(x) = a x + b$$
-	$a$, $b$ werden über die Anfbangsbedingungen$(x_1, y_1)$ und $(x_2, y_2)$ festgelegt.
+	$a$, $b$ werden über die Anfangsbedingungen$(x_1, y_1)$ und $(x_2, y_2)$ festgelegt.
 \end{beispiel*}
 
 \begin{beispiel*}[Minimale Rotationsfläche]~\\
@@ -747,21 +747,21 @@ Ein Hinweis am Rande: Die Kurve, welche durch den Kosinus Hyperbolicus beschrieb
 \end{beispiel*}
 
 \subsubsection{Verallgemeinerung des Variationsproblems auf mehrere Variablen}
-\textit{\dots und damit die Eulergleichung natürlich auch.}\\
+\textit{\dots und damit die Euler-Gleichung natürlich auch.}\\
 Das betrachtete $y$ wird nun als Vektor $\vec{y}(x) = (y_1(x), \dots, y_s(x))$ geschrieben und ganz analog
 $$\delta J = \int_{x_1}^{x_2} \d x \sum_{i=1}^{s} (\ffpartial{f}{y_i} - \dd x \ffpartial{f}{y'_i}) \delta y_i = 0$$
 Hierbei sind $\delta y_i$ die unabhängigen Freiheitsgrade. Offensichtlich gibt es eine Gleichung pro Freiheitsgrad
 \begin{align*}
 \ffpartial{f}{y_i} - \dd x \ffpartial{f}{y'_i} &= 0, i = 1, \dots, s
-\intertext{Dies stellt in etwa die Euler-Langrange-Gleichungen dar. Nun kann man das Hamiltonische Prinzip anwenden}
+\intertext{Dies stellt in etwa die Euler-Lagrange-Gleichungen dar. Nun kann man das Hamiltonsche Prinzip anwenden}
 \delta \int L(t, \vec{q}, \dotvec{q}) \d t &\overset{!}{=} 0
-\intertext{Es funktioniert also völlig analog, damit bekommt man Langrangegleichungen 2. Art}
+\intertext{Es funktioniert also völlig analog, damit bekommt man Lagrange-Gleichungen 2. Art}
 \dd t \ffpartial{L}{\dot{q}_i} - \ffpartial{L}{q_i} &= 0
 \end{align*}
 \conseq \textbf{Hamiltonsches Prinzip}
-Das Integralprinzip (Hamilton) und das differentielle Prinzip (d'Alembert) sind äquivalent. Beide führen auf die Lagrangegleichungen. 
+Das Integralprinzip (Hamilton) und das differentielle Prinzip (d'Alembert) sind äquivalent. Beide führen auf die Lagrange-Gleichungen. 
 
-\textit{Das Hamiltonsche Prinzip wird ausgiebig in der Quantenmechanik verwendet. Im folgenden wird weiter auf die Hamiltonfunktion eingegangen um als Ziel sich in die Quantenmechanik zu bewegen. Es werden im speziellen Eigenschaften der Hamilton-Funktion angegeben.}
+\textit{Das Hamiltonsche Prinzip wird ausgiebig in der Quantenmechanik verwendet. Im folgenden wird weiter auf die Hamilton-Funktion eingegangen um als Ziel sich in die Quantenmechanik zu bewegen. Es werden im speziellen Eigenschaften der Hamilton-Funktion angegeben.}
 
 \subsubsection{Erhaltungsgrößen}
 \paragraph{Allgemeines System} Die allgemeinen Koordinaten $q_i$, $\dot{q}_i$ für $i = 1, \dots, s$ sind im Laufe der Zeit veränderlich, womit es $2S$ Funktionen der Zeit gibt. Einige von diesen sind jedoch konstant\footnote{Mathematisch ausgedrückt gilt dann $F_r = F_r(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t) = \text{konstant}$.}, was nicht Zufall sein muss.\footnote{Es ist aus offensichtlichen das Ziel, dass möglichst viele Funktionen konstant sind. Denn wie man schon im Lagrange-Teil gesehen hat, wird damit die Komplexität des Problems reduziert.}
@@ -790,14 +790,14 @@ V(\vec{r}_1, \vec{r}_2) &= V(| \vec{r}_1 - \vec{r}_2|) = V(r)\\
 Die generalisierten Koordinaten sind in unserem Beispiel
 \begin{align*}
 \vec{R} &= (q_1, q_2, q_3) \text{~mit~} r = q_4, \vartheta = q_5, \varphi = q_6
-\intertext{Damit ist die Lagrangefunktion in den generalisierten Koordinaten}
+\intertext{Damit ist die Lagrange-Funktion in den generalisierten Koordinaten}
 	L &= \frac{M}{2} (\dot{q}_1^2 + \dot{q}_2^2 + \dot{q}_3^2) \\~&- V(q_4) + \frac{\mu}{2} (\dot{q}_4^2 + q_4^2 \dot{q}_5^2 + q_4^2 \dot{q}_6^2 \sin^2 q_5)
-	\intertext{Offensichtlich sind die Koordinaten $q_1, q_2, q_3, q_6$ zyklisch und $p_i = \ffpartial{L}{\dot{q}_i} = M \dot{q}_i$ für ($i =1, 2, 3$), also bleibt der \textit{Schwerpunktsimpuls} erhalten.}
+	\intertext{Offensichtlich sind die Koordinaten $q_1, q_2, q_3, q_6$ zyklisch und $p_i = \ffpartial{L}{\dot{q}_i} = M \dot{q}_i$ für ($i =1, 2, 3$), also bleibt der \textit{Schwerpunktimpuls} erhalten.}
 	\vec{p} &= M \dotvec{R} = \text{konstant}\\
 	p_6 &= \ffpartial{L}{\dot{q}_6} = \mu q_4^2 \dot{q}_6 \sin^2 q_5 = \mu \dot{\varphi} r^2 \sin^2 \vartheta = L_r^{(Z)} = \text{konstant}
 \end{align*}
 Die $z$-Komponente des Relativdrehimpulses ist ersichtlicherweise konstant\footnote{Vergleiche: Geworfenes Frisbee, dessen Drehachse relativ gesehen sich nicht verändert.\footnote{Tipp: Dies mit einer Tafelkreide zu probieren ist aufgrund des vergleichsweise geringen Impulses schlecht möglich.}}.
-Wenn man das Problem nun versucht in den Kartesischen Koordinaten anzugehen, führt das folgender Langrange-Funktion.
+Wenn man das Problem nun versucht in den Kartesischen Koordinaten anzugehen, führt das folgender Lagrange-Funktion.
 \begin{align*}
 	L =& \frac{m_1}{2} (\dot{x}_1^2 + \dot{y}_1^2 + \dot{z}_1^2) + \frac12 m_2 (\dot{x}_2^2 + \dot{y}_2^2 + \dot{z}_2^2) \\
 	&- V((x_1 - x_2)^2 + (y_1 - y_2)^2 + (z_1 - z_2)^2)
@@ -816,7 +816,7 @@ Daraus folgt die zeitweise Homogenität. Sie ist offenbar erfüllt, da die Lagra
 $$\ddd{L}{t} = \sum_{j=1}^{s} (\underbrace{\ffpartial{L}{q_j}}_{\dd t \ffpartial{L}{\dot{q}_j}} \dot{q}_j + \ffpartial{L}{\dot{q}_j} \ddot{q}_j) + \underbrace{\ffpartial{L}{t}}_{= 0} = \sum_{j = 1}^s [ (\dd t \ffpartial{L}{\dot{q}_j}) \dot{q}_j + \ffpartial{L}{\dot{q}_j} \ddot{q}_j] = \dd t \sum_{j=1}^s \ffpartial{L}{\dot{q}_j} \dot{q}_j$$
 also gilt insgesamt
 $$\dd t (L - \sum_{j=1}^s \ffpartial{L}{\dot{q}_j} \dot{q}_j) = 0$$
-mit dem generalisiertem Impuls $p_j = \ffpartial{L}{\dot{q}_j}$ folgt die Hamiltonfunktion
+mit dem generalisiertem Impuls $p_j = \ffpartial{L}{\dot{q}_j}$ folgt die Hamilton-Funktion
 $$H = \sum_{j=1}^s p_j \dot{q}_j - L$$
 für die nach Konstruktion gilt $\ddd{H}{t} = 0$, oder anders ausgedrückt, dass $H = \text{konstant}$ gilt.
 
@@ -834,9 +834,9 @@ erkennt man, dass gilt
 $$\ffpartial{T}{a} = \sum_{j=1}^s \ffpartial{T}{(a \dot{q}_j)}\dot{q}_j = 2 a T$$
 womit für $a = 1$ schlussendlich  gilt
 $$ 2 T = \sum_{j=1}^s \ffpartial{T}{\dot{q}_j} \dot{q}_j = \sum_{j=1}^s \ffpartial{L}{\dot{q}_j} = \sum_{j=1}^s p_j \dot{q}_j$$
-Mit dieser Erkenntnis kann man nun die Hamiltonfunktion umformen zu
+Mit dieser Erkenntnis kann man nun die Hamilton-Funktion umformen zu
 $$H = \sum_{j=1}^s p_j \dot{q}_j - L = 2T - L = 2 T - (T-V) = T + V = E$$
-Damit kann man die Hamiltonfunktion als Gesamtenergie des Systems interpretieren.
+Damit kann man die Hamilton-Funktion als Gesamtenergie des Systems interpretieren.
 
 
 
@@ -846,7 +846,7 @@ Damit kann man die Hamiltonfunktion als Gesamtenergie des Systems interpretieren
 \paragraph{Zusammengefasst}
 Aus der Homogenität in der Zeit folgt
 \[H=\sum\limits_{j=1}^S p_j\dot q_j - L = \const\]
-Falls die Zwangsbedingungen skleronom sind, folgt daraus die \emph{Energieerhaltung}, denn die Hamiltonfunktion ist die Gesamtenergie.
+Falls die Zwangsbedingungen skleronom sind, folgt daraus die \emph{Energieerhaltung}, denn die Hamilton-Funktion ist die Gesamtenergie.
 
 \subsubsection{Homogenität des Raums}
 Wenn etwas räumlich homogen ist, bedeutet das, dass es unabhängig vom Ort (Anfangsbedingungen) ist. Eine Verschiebung des Systems verändert nicht die Dynamik. Damit ist ein solches System in der Regel nur von den relativen Abständen abhängig.
@@ -886,9 +886,9 @@ Isotropie  $\Leftrightarrow$ Drehimpulserhaltung
 \end{bemerkung*}
 
 \section{Hamilton-Mechanik}
-Die Hamiltonsche Mechanik ist eine Weiterentwicklung der Lagrangemechanik. Sie ist ein a posteriori\footnote{"'Eine Theorie, die a posteriori gebildet wurde, erfüllt hinsichtlich ihrer Wissenschaftlichkeit zunächst nur das Kriterium der Erklärungskraft und muss sich in anderer Hinsicht (Nachvollziehbarkeit, Überprüfbarkeit, Falsifizierbarkeit, Voraussagekraft) noch bewähren."' \href{https://de.wikipedia.org/wiki/A_posteriori}{wikipedia}} wichtiger Schritt auf dem Weg zur Quantenmechanik. Die Klassische Mechanik wird später zum "`Grenzfall"' der Übergeordneten Quantenmechanik. Ein der Quantenmechanik ähnliche mathematische Struktur lässt sich bereits hier entwickeln.
+Die Hamiltonsche Mechanik ist eine Weiterentwicklung der Lagrange-Mechanik. Sie ist ein a posteriori\footnote{"'Eine Theorie, die a posteriori gebildet wurde, erfüllt hinsichtlich ihrer Wissenschaftlichkeit zunächst nur das Kriterium der Erklärungskraft und muss sich in anderer Hinsicht (Nachvollziehbarkeit, Überprüfbarkeit, Falsifizierbarkeit, Voraussagekraft) noch bewähren."' \href{https://de.wikipedia.org/wiki/A_posteriori}{wikipedia}} wichtiger Schritt auf dem Weg zur Quantenmechanik. Die Klassische Mechanik wird später zum "`Grenzfall"' der Übergeordneten Quantenmechanik. Ein der Quantenmechanik ähnliche mathematische Struktur lässt sich bereits hier entwickeln.
 
-Der Ausgangspunkt ist offensichtlich die Lagrangemechanik. Jetzt wird $(\vec q, \dot {\vec q})$ zu $(\vec q, \vec p, t)$ transformiert.
+Der Ausgangspunkt ist offensichtlich die Lagrange-Mechanik. Jetzt wird $(\vec q, \dot {\vec q})$ zu $(\vec q, \vec p, t)$ transformiert.
 
 Die $p_i$ sind die zu $q_i$ kanonisch konjugierten Impulse, sie werden als unabhängige Funktion (von $\vec q$) aufgefasst.
 \[\text{Lagrange}\to\text{Hamilton}\]
@@ -929,7 +929,7 @@ Zuerst betrachten wir den Fall der Funktion $f(x,y)$, bei der $y$ durch $v$ erse
 \[g(x,y) = f(x,y) - y(\frac{\partial f}{\partial y})_x\]
 die Legendre-Transformation von $f(x,y)$ bezüglich $y$ ist.
 
-Die Legendre-Transformation der Lagrangefunktion bezüglich der Geschwindigkeiten $\dot q_j$ haben wir schon kennengelernt. Mit $p_j = \frac{\partial L}{\partial \dot q_j}$ folgt daraus die \emph{Hamiltonfunktion}
+Die Legendre-Transformation der Lagrange-Funktion bezüglich der Geschwindigkeiten $\dot q_j$ haben wir schon kennengelernt. Mit $p_j = \frac{\partial L}{\partial \dot q_j}$ folgt daraus die \emph{Hamilton-Funktion}
 \[H(q_1,\ldots q_S,  p_1,\ldots, p_S,t) = (\sum\limits_{i=1}^S p_i \dot q_i) - L(q_1, \ldots,q_S, \dot q_1, \ldots, \dot q_S, t)\]
 \textit{Auch negative Legendre-Transformierte genannt}.
 Die Wahl von $H$ ist eine gute Wahl, da $H$ eng mit der Energie des Systems verknüpft ist. Denn, wie schon erwähnt, ist $G$ die Energie für holonom-skleronome Systeme!
@@ -967,7 +967,7 @@ dann für $H$:
 $$\dot{p}_j = 0 = -\ffpartial{H}{q_j}$$
 \conseq zyklische Koordinaten erscheinen auch nicht in H.
 $p_j$ wird durch die Anfangsbedingung $p_j = c_j$ festgelegt. Das System hat also praktisch nur noch $(2S -2)$ Freiheitsgrade.
-$H$ ist nicht mehr von $q_j$, $p_j$ abhängig. Vgl. $L$, hier immer noch $\dot{q}_j$ Abhändigkeit in der Lagrangefunktion, d.h. wir haben hier einen klaren Vorteil des Hamiltonformalismus.
+$H$ ist nicht mehr von $q_j$, $p_j$ abhängig. Vgl. $L$, hier immer noch $\dot{q}_j$ Abhängigkeit in der Lagrange-Funktion, d.h. wir haben hier einen klaren Vorteil des Hamiltonformalismus.
 
 \subsubsection{Vorgehen im Hamiltonformalismus als Rezept}
 \begin{enumerate}
@@ -1006,7 +1006,7 @@ $H$ ist nicht mehr von $q_j$, $p_j$ abhängig. Vgl. $L$, hier immer noch $\dot{q
 	p = \ffpartial{L}{\dot{q}} = m l^2 \dot{q} \rightarrow \dot{q} = \frac{p}{m l^2}
 	\intertext{$L$ mit $\dot{q} \rightarrow p$}
 	\tilde{L}(q, p) = \frac{p^2}{2 m l^2} + mgl\cos q
-	\intertext{H aus Legendretransformation}
+	\intertext{H aus Legendre-Transformation}
 	H = p \dot{q} - L = \frac{p^2}{m l^2} - \frac{p^2}{2ml^2} - m g l \cos q\\
 	&=  \frac{p^2}{2 ml^2} - mgl \cos q
 	\intertext{Kanonische Bewegungsgleichungen:}
@@ -1082,7 +1082,7 @@ $$\dot{\Psi}(t) = \tilde{\Psi}(\Psi(t))$$
 \textit{In der Quantenmechanik ist dies die Schrödingergleichung.}\\
 Daraus folgen die Hamiltonschen kanonischen Gleichungen
 $$\dotvec \pi (t) = \tilde{\Psi}(\vec{\pi}(t))$$
-Die Hamiltonfunktion spielt eine fundamentale Rolle.
+Die Hamilton-Funktion spielt eine fundamentale Rolle.
 
 \newcommand{\vpi}{\vec{\pi}}
 \newcommand{\poisson}[1]{\{#1\}_{\vec{p}, \vec{q}}}
@@ -1115,7 +1115,7 @@ Im folgenden eine Diskussion weiterer formaler Eigenschaften\footnote{der klassi
 \end{bemerkung*}
 \todo{is $\dot{q}_j = \poisson{q, H}$ correct??}
 
-\subsubsection{Die fundamentalen Poissonklammern}
+\subsubsection{Die fundamentalen Poisson-Klammern}
 \begin{align*}
 \poisson{q_i, q_j} &= \poisson{p_i, p_j} = 0\\
 \poisson{q_i, p_j} &= \delta_{ij}
@@ -1159,11 +1159,11 @@ $F$, $G$; $\vec{q}$, $\vec{p}$ bzw. $\vec{Q}$, $\vec{P}$ wie oben
 	\rightarrow \ffpartial{f}{t} &= \{f, H\} + \ffpartial{f}{t}
 \end{align*}
 
-Die Poissonklammer hängt also nicht von der Wahl der kanonisch konjugierten Variablen ab. Die Koordinaten als Index können deswegen weggelassen werden.
+Die Poisson-Klammer hängt also nicht von der Wahl der kanonisch konjugierten Variablen ab. Die Koordinaten als Index können deswegen weggelassen werden.
 $$\{F, G\}_{\vec{q}, \vec{p}} = \{F, G\}_{\vec{Q}, \vec{P}} = \{F, G\}$$
-Die Poissonklammer kann auch als algebraisches Konstrukt mit den folgenden Eigenschaften betrachtet werden 
+Die Poisson-Klammer kann auch als algebraisches Konstrukt mit den folgenden Eigenschaften betrachtet werden 
 \begin{description}
-	\item[Linerarität] $\{c_1 f_1 + c_2 f_2, g\} = c_1 \{f_1, g\} + c_2 \{f_2, g\}$ ($c_1$, $c_2$ konstant)
+	\item[Linearität] $\{c_1 f_1 + c_2 f_2, g\} = c_1 \{f_1, g\} + c_2 \{f_2, g\}$ ($c_1$, $c_2$ konstant)
 	\item[Antisymmetrie] $\{f, g\} = - \{g, f\}$ \conseq $\{f, f\} = 0$
 	\item[Nullelement] $\{c, f\} = 0$, $f=f(\vec{q}, \vec{p})$; $c = \const$
 	\item[Produktregel] $\{f, g h\} = g \{f, h\} + \{f, g\} h$
@@ -1180,18 +1180,18 @@ Observable: $f = f(\vec{q}, \vec{p}, t) = f(\vec{\pi}, t)$, $\ddd{f}{t} = \{f, H
 D.h. für \textit{Integrale der Bewegung}
 $\ddd{f}{t} = 0 \Leftrightarrow \{H, f\} = \ffpartial{f}{t}$
 insbesondere, wenn $f$ nicht explizit zeitabhängig. Kenntnis der Integrale der Bewegung wesentlich für die Lösung eines dynamischen Problems \conseq Hier: einfaches Kriterium.
-Einfacher Test: $f = H$: $\ddd{H}{t} = \{H, H\} + \ffpartial{H}{t} = \ffpartial{H}{t}$ schon bekannt. (bei skeleronomen Zwangsbedingungen = Energiesatz) 
-Bis hierhin ausführliche Diskussion der Poissonklammern als mathematisches Werkzeug der klassischen Mechanik.
+Einfacher Test: $f = H$: $\ddd{H}{t} = \{H, H\} + \ffpartial{H}{t} = \ffpartial{H}{t}$ schon bekannt. (bei skleronomen Zwangsbedingungen = Energiesatz) 
+Bis hierhin ausführliche Diskussion der Poisson-Klammern als mathematisches Werkzeug der klassischen Mechanik.
 \conseq jetzt die abstrakten Eigenschaften der Klammer werden verallgemeinert
 Das gibt uns eine andere Realisierung der Klammer, was uns (fast) die ganze Quantenmechanik gibt.
 
 \newcommand{\fihbar}{\frac{1}{i \hbar}}
 
 \section{Ausblick auf die Quantenmechanik}
-Jetzt sei $\{,\}$ eine abstrakte Klammer mit den abstrakte Eigenschaften der Poissonklammer, wir verstehen diese als mathematische Struktur.
-Eine Realisierung dieser Struktur ist die Poissonklammer \conseq klassische Mechanik.
+Jetzt sei $\{,\}$ eine abstrakte Klammer mit den abstrakte Eigenschaften der Poisson-Klammer, wir verstehen diese als mathematische Struktur.
+Eine Realisierung dieser Struktur ist die Poisson-Klammer \conseq klassische Mechanik.
 Alternativ: \textit{Quantenmechanik}
-Hier sind Observablenlineare Operatoren $A$, $B$, $C$, \dots auf Hilberträumen. Z.B. $A,B,C = $ Matrizen auf gewöhnlichen Vektoren. Definiere Klammer jetzt als Kommutator $[A,B] = AB - BA$
+Hier sind Observable lineare Operatoren $A$, $B$, $C$, \dots auf Hilberträumen. Z.B. $A,B,C = $ Matrizen auf gewöhnlichen Vektoren. Definiere Klammer jetzt als Kommutator $[A,B] = AB - BA$
 als die abstrakte mathematische Struktur. Konkret können Operatoren Matrizen sein. Hier nicht Nichtkommutativität z.B. von Drehungen bekannt. "`Reihenfolge der Operatoren ist relevant"'.
 Konkrete Formulierung der Quantenmechanik auf Grund dieser mathematischen Struktur wäre folgendes
 \begin{enumerate}
@@ -1199,9 +1199,9 @@ Konkrete Formulierung der Quantenmechanik auf Grund dieser mathematischen Strukt
 	\item Mögliche Messwerte von $A$ = Eigenwerte von A
 	\item $\{\dots, \dots\} \equiv \fihbar [A, B]$ mit $\hbar = \frac{h}{2 \pi}$
 	\item Fundamentalklammern
-	$[q_i, p_j] = i \hbar \delta_{ij}$ (analog zur Poissonklammer)\\
+	$[q_i, p_j] = i \hbar \delta_{ij}$ (analog zur Poisson-Klammer)\\
 	$[q_i, q_j] = [p_i, p_j] = 0$
-	\item Hamiltonfunktion $H(\vec{q}, \vec{p}, t) \leftrightarrow $ Hamiltonoperator $H$ (Eigenwerte sind die möglichen Energiezustände)
+	\item Hamilton-Funktion $H(\vec{q}, \vec{p}, t) \leftrightarrow $ Hamiltonoperator $H$ (Eigenwerte sind die möglichen Energiezustände)
 	\item Bewegungsgleichung\footnote{Auch als Heisenbergsche Bewegungsgleichung bekannt, vgl. \href{https://de.wikipedia.org/wiki/Heisenbergsche_Bewegungsgleichung}{Wikipedia}}
 	$$\dd t A = \fihbar [A, H] + \ffpartial{A}{t}$$
 	\conseq Postulate der Quantenmechanik.
@@ -1214,7 +1214,7 @@ Konkrete Formulierung der Quantenmechanik auf Grund dieser mathematischen Strukt
 %Formale Entwicklung der Theorie führten zu radikalen Konsequenzen (eventuell etwas Allgemeine Relativitätstheorie)
 
 \paragraph{Begriff} Wie beobachtet man physikalische Phänomene \textbf{relativ} zueinander bewegter Bezugssysteme? Und wie steht es um die Invarianz/Kovarianz physikalischer Observablen und Gesetze.
-Bei gleichförmig geradlinig zueinander bewegten Systemen (Inertialsysteme) wird die \textbf{spezielle} Relativitätstheorie angewendet, darüber hinaus gibt es für gegeneinander beschleunigt bewegte Bezugssysteme die \textbf{allgemeine} Relativitätstheorie: Aus den Beschleunigungen folgen Scheinkräfte und die Gravitationkräfte werden als Eigenschaft von Raum und Zeit beschrieben.
+Bei gleichförmig geradlinig zueinander bewegten Systemen (Inertialsysteme) wird die \textbf{spezielle} Relativitätstheorie angewendet, darüber hinaus gibt es für gegeneinander beschleunigt bewegte Bezugssysteme die \textbf{allgemeine} Relativitätstheorie: Aus den Beschleunigungen folgen Scheinkräfte und die Gravitationskräfte werden als Eigenschaft von Raum und Zeit beschrieben.
 
 Im folgenden betrachten wir "`nur"' die spezielle Relativitätstheorie.
 Das wichtigste Kriterium für sogenannte relativistische Phänomene sind die Geschwindigkeiten aller beteiligten Systeme:
@@ -1385,7 +1385,7 @@ y'&=y\\
 z'&=\gamma (z - \beta c t)\\
 ct' &= \gamma (ct - \beta z)
 \end{align*}
-Dies sind die \textbf{Lorentztransformationsformeln}. Die Zeit wird offensichtlich mittransformiert, dies war bei der Galilei-Transformation nicht der Fall
+Dies sind die \textbf{Lorentz-Transformationsformeln}. Die Zeit wird offensichtlich mit transformiert, dies war bei der Galilei-Transformation nicht der Fall
 
 \begin{bemerkung*}
 	Der Grenzfall bei $v \ll c$ ist die Galilei-Transformation.
@@ -1561,7 +1561,7 @@ $$K^\mu = m \ddd{u^\mu}{\tau}$$
 zunächst nur räumliche Komponenten
 \begin{align*}
 	K^i &= m \dd \tau u^i = m \gamma \dd t u^i = m \gamma \dd t \gamma v^i\\
-	&= \gamma \dd t \underbrace{m \gamma v^i}_{= p^i \text{~räumliche Komponente des relatistischen Impulses}}\\
+	&= \gamma \dd t \underbrace{m \gamma v^i}_{= p^i \text{~räumliche Komponente des relativistischen Impulses}}\\
 	p^i &= \gamma m v^i \xrightarrow{\gamma \to 1} m v^i\\
 	K^i = \gamma F^i \xrightarrow{\gamma \to 1} F^i
 \end{align*}
@@ -1645,7 +1645,7 @@ Energie / Volumen $a^3$
 Alternatives phänomenologisches Gesetz (Wien)
 $$g(\frac{\nu}{T}) = a e^{- b \frac{\nu}{T}}$$
 Wir suchen eine Interpolation der Daten.\\
-Gesamtenergie $\int_0^\infty W_\nu \d \nu = \infty$ \textbf{Ultraviolettkatastrophe}\\
+Gesamtenergie $\int_0^\infty W_\nu \d \nu = \infty$ \textbf{Ultraviolett-Katastrophe}\\
 Ausweg: \textbf{Plancksche Strahlungsformel}\\
 Austausch zwischen Strahlung und Wand mit linearen Oszillatoren in der Wand.\\
 (klassisch): Jede Energie der Oszillatoren erlaubt.\\
@@ -1678,7 +1678,7 @@ Phänomene, die auf den Teilchencharakter des Lichtes und auf den Wellencharakte
 
 \subsubsection{Interferenz von Lichtwellen}
 \textbf{Doppelspaltexperiment}\\
-monchromatisches Licht $\lambda$\\
+monochromatisches Licht $\lambda$\\
 Konstruktive Interferenz wenn Gangunterschied $g = m \cdot \lambda$\\
 Destruktive Interferenz bei $g = (m - \frac12) \lambda$\\
 $\cos \alpha = \frac{m\lambda}{d}$ Maxima der Lichtintensität\\
@@ -1706,7 +1706,7 @@ Licht mit Frequenz $\nu$ trifft mit Intensität $I$ auf Material und schlägt \c
 	\item[\conseq] Schrödingergleichung, Ortsdarstellung (zeitunabhängige Darstellung?) \conseq "`Wellenmechanik"'
 	\item Postulate der \QM
 	\item Symmetrien und Erhaltungssätze, insbesondere Drehimpuls, Spin
-	\item Wasserstofatom \conseq Periodensystem der Elemente
+	\item Wasserstoffatom \conseq Periodensystem der Elemente
 	\item Identische Teilchen (Bosonen und Fermionen)
 	\item Mindestens die Hälfte mit Quantenmechanik
 \end{itemize}
@@ -1727,7 +1727,7 @@ Licht mit Frequenz $\nu$ trifft mit Intensität $I$ auf Material und schlägt \c
 
 
 \subsection{Newtonsche Gesetze}
-\begin{definition*}[1. Gesetz \textit{Galileiisches Trägheitsgesetz}] 
+\begin{definition*}[1. Gesetz \textit{Galileisches Trägheitsgesetz}] 
 	\textbf{Inertialsysteme} in welchen ein kräftefreier Körper ruht oder sich geradlinig und gleichförmig bewegt.
 \end{definition*}
 
@@ -1737,7 +1737,7 @@ Licht mit Frequenz $\nu$ trifft mit Intensität $I$ auf Material und schlägt \c
 	\end{equation*}
 \end{definition*}
 
-\begin{definition*}[2. Gesetz \textit{Newtonsches Bewegungssgesetz}]
+\begin{definition*}[2. Gesetz \textit{Newtonsches Bewegungsgesetz}]
 	\begin{equation*}
 	\dot{\vec{p}} = \vec{F}, \dot{\vec{v}} = \vec{a} \rightarrow \vec{F} = m \vec{a}
 	\end{equation*}
@@ -1806,7 +1806,7 @@ Im folgenden quasi ausschließlich holonome Zwangsbedingungen betrachtet.
 \paragraph{\textit{B} nicht holonome Zwangsbedingung} können nur als Ungleichungen oder differentielle Einschränkungen dargestellt werden, was die Arbeit mit ihnen, gegenüber den holonomen, erschwert.
 
 \subsubsection{Verallgemeinerte Koordinaten}
-Zwangbedingungen formulieren Zwangskräfte implizit und sind einfacher als selbige. Ziel: Elimination der Zwangskräfte.
+Zwangsbedingungen formulieren Zwangskräfte implizit und sind einfacher als selbige. Ziel: Elimination der Zwangskräfte.
 
 \paragraph{Holonome Zwangsbedingungen}
 Hier, wie im folgenden, werden ausschließlich holonome Zwangsbedingen betrachtet. Bei ihnen führt die Verwendung verallgemeinerter Koordinaten zu einer Reduktion der Freiheitsgrade\footnote{Wenn im folgenden von $S$ oder $s$ die Rede ist, ist immer die Anzahl der Freiheitsgrade gemeint.} auf $S = 3N - p$. Hierbei ist, wie im folgenden oft, $p$ die Anzahl der holonomen Zwangsbedingungen. 
@@ -1874,25 +1874,25 @@ $$\forall i:  \dd t ( \ffpartial{T}{\dot{q}_j}) - \ffpartial{T}{q_j} - Q_j = 0$$
 In einem konservativen System ist die Kraft $Q_j$ auf ein Potential $V_j$ zurückzuführen. Das Potential V, und damit auch die generalisierte Kraft $Q_j = - \ffpartial{V}{q_j}$, ist unabhängig von der Geschwindigkeit $\dot{q}_j$. Anders ausgedrückt gilt
 $$\ffpartial{V}{\dot q_j} = 0 \text{~ und damit ~} \sum_{j=1}^s \{  \dd{t} \fpartial{\dot{q}_j} (T-V) - \fpartial{q_j} (T -V) \} \delta q_j = 0$$
 
-\subsubsection{Langangefunktion}
-Man kann die Gleichungen auch wie folgt schreiben, wenn man die Lagrangefunktion $L$ einführt.
+\subsubsection{Langange-Funktion}
+Man kann die Gleichungen auch wie folgt schreiben, wenn man die Lagrange-Funktion $L$ einführt.
 $$L(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t) = T(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t) - V(q_1, \dots, q_s)$$
 
-\subsubsection{Lagrangegleichung \textit{1. Art}}
+\subsubsection{Lagrange-Gleichung \textit{1. Art}}
 $$\sum_{j = 1}^s  (  \dd{t} \ffpartial{L}{\dot{q}_j} - \ffpartial{L}{q_j}  ) \delta q_j = 0$$
 
-\subsubsection{Lagrangegleichung \textit{2. Art}}
+\subsubsection{Lagrange-Gleichung \textit{2. Art}}
 Gegeben sei wieder ein konservatives System mit holonomen Zwangsbedingungen.
 $$ \dd{t} \ffpartial{L}{\dot{q}_j} - \ffpartial{L}{q_j} = 0 \text{~für~} j= 1, \dots, s$$
 
 \begin{bemerkung*}[Fazit]~\\
-	Mit den Lagrangegleichungen wurden die Zwangskräfte eliminiert. Man hat dafür $S$ gewöhnliche Differenzialgleichungen 2. Ordnung bekommen, für welche man $2S$ Anfangsbedingungen benötigt um sie zu lösen.
+	Mit den Lagrange-Gleichungen wurden die Zwangskräfte eliminiert. Man hat dafür $S$ gewöhnliche Differenzialgleichungen 2. Ordnung bekommen, für welche man $2S$ Anfangsbedingungen benötigt um sie zu lösen.
 	Statt Impuls und Kraft, wie bei den Newtonschen Gesetzen, liegen hierbei Energie und Arbeit im Fokus.
 \end{bemerkung*}
 
 \begin{bemerkung*}[Ausblick]
 	$$L = L(\vardots{q}{s}, \vardots{\dot{q}}{s}, t)$$
-	Die Lagrangegleichungen sind invariant gegenüber Punkttransformationen \\
+	Die Lagrange-Gleichungen sind invariant gegenüber Punkttransformationen \\
 	$(\vardots{q}{s}) \underset{\text{differenzierbar}}{\leftrightarrow} (\vardots{\bar{q}}{s})$ mit $\bar{q}_i = \bar{q}_i(\vardots{q}{s}, t)$, $q_i = q_i(\vardots{\bar{q}}{s}, t)$
 	Damit hat man bei der Wahl der generalisierten Koordinaten gewisse Freiheiten. Diese kann man zur Vereinfachung des Problems nutzen. Hierbei ist es sinnvoll weitere Symmetrien im Problem auszunutzen.
 \end{bemerkung*}
@@ -1977,7 +1977,7 @@ $$ \dd{t} \ffpartial{L}{\dot{q}_j} - \ffpartial{L}{q_j} = 0 \text{~für~} j= 1, 
 	\dd t \ffpartial{L}{\dot{q}_2} &= m_2 (l^2 \ddot{q}_2 + l \ddot{q}_1 \cos q_2 - l \dot{q}_1 \dot{q}_2 \sin q_2)\\
 	\ffpartial{L}{q_2} &= m_2 (- l \dot{q}_1 \dot{q}_2 \sin q_2 - g l \sin q_2)\\
 	0 &= m_2 (l^2 \ddot{q}_2 + l \ddot{q}_1 \cos q_2 + g l \sin q_2)\\
-	\intertext{Jetzt $\ddot{q}_1$ von oben (per Differentation)}
+	\intertext{Jetzt $\ddot{q}_1$ von oben (per Differentiation)}
 	\ddot{q}_1 &= - \frac{m_2 l}{m_1 + m_2} (\ddot{q}_2 \cos q_2 - \dot{q}_2^2 \sin q_2)
 	\end{align*}
 	Damit erhält man die $q_2$-Gleichung
@@ -1995,8 +1995,8 @@ Für die häufigsten Fälle mit \textbf{holonomen} Zwangsbedingungen und \textbf
 \begin{enumerate}
 	\item Zwangsbedingungen formulieren
 	\item Generalisierte Koordinaten festlegen
-	\item Lagrangefunktion hinschreiben (mit generalisierten Koordinaten und Geschwindigkeiten)
-	\item Lagrangefunktion ableiten und wenn möglich lösen
+	\item Lagrange-Funktion hinschreiben (mit generalisierten Koordinaten und Geschwindigkeiten)
+	\item Lagrange-Funktion ableiten und wenn möglich lösen
 	\item Eventuell Rücktransformation auf gewöhnliche Koordinaten
 \end{enumerate}
 
@@ -2037,7 +2037,7 @@ Für die häufigsten Fälle mit \textbf{holonomen} Zwangsbedingungen und \textbf
 \end{beispiel*}
 }
 
-\subsection{Das Hamiltonische Prinzip}	
+\subsection{Das Hamiltonsche Prinzip}	
 Bahnen im Konfigurationsraum\dots
 
 \begin{definition*}[Wirkungsintegral]
@@ -2046,7 +2046,7 @@ Bahnen im Konfigurationsraum\dots
 \end{definition*}
 
 
-Beim Hamiltonische Prinzip wird nun die Bahn des Systems betrachtet und wollen eine extremale Bahn finden.
+Beim Hamiltonsche Prinzip wird nun die Bahn des Systems betrachtet und wir wollen eine extremale Bahn finden.
 
 ~\\
 Die Systembewegung erfolgt so, dass $S{\vec{q}(t)}$ für die richtige Trajektorie extremal, d.h. dass die Variation bezüglich der tatsächlichen Bahn verschwindet.
@@ -2061,8 +2061,8 @@ Finden der Kurve $\vec{q}(t)$, die $S\{\vec{q}(t)\}$ extremal macht.
 
 \subsubsection{Elemente der Variationsrechnung}
 
-\begin{definition*}[Eulergleichung]
-	Wie die Lagrangegleichung, gilt aber ganz allgemein für Variationsprobleme.
+\begin{definition*}[Euler-Gleichung]
+	Wie die Lagrange-Gleichung, gilt aber ganz allgemein für Variationsprobleme.
 	$$ \ffpartial{f}{y} - \dd x \ffpartial{f}{y'} = 0$$++++
 \end{definition*}
 
@@ -2087,7 +2087,7 @@ y_\alpha(x) &= y_0(x) + \gamma_\alpha(x)
 \gamma_\alpha(x) &= y_0(x) + \alpha(\ffpartial{y_\alpha}{\alpha})_{\alpha = 0} + \dots
 \end{align*}
 
-$y_\alpha(x)$ wird nun in der Nähe (besser gesagt in der $\epsilon$-Umgebung) von $\alpha = 0$ variert. Daraus folgt, dass $\alpha \rightarrow \d \alpha$.
+$y_\alpha(x)$ wird nun in der Nähe (besser gesagt in der $\epsilon$-Umgebung) von $\alpha = 0$ variiert. Daraus folgt, dass $\alpha \rightarrow \d \alpha$.
 Und damit $\delta y = y_{\d \alpha} - y_0(x) = \d \alpha (\ffpartial{y_\alpha(x)}{\alpha})_{\alpha = 0}$.
 Wird nun $\delta y$ bei festem $x$ betrachtet (vgl. virtuelle Verrückungen bei fester Zeit t. ($\delta t = 0$)) kommt man zu einer Variation des Funktionals $J\{y(x)\}$
 $$\delta J \{ y_{\d \alpha}(x) \} - J\{ y_0(x)\} = (\ddd{J(x)}{\alpha})_{\alpha = 0} \d \alpha = \int_{x_1}^{x_2} (f(x, y_{\d \alpha}, y'_{\d \alpha}) - f(x, y_0, y'_0)) \d x$$\todo{vorher Zusatz???}
@@ -2107,11 +2107,11 @@ $$\ffpartial{f}{y} - \dd x \ffpartial{f}{y'} = 0$$
 Und damit eine Differentialgleichung 2. Ordnung für das gesuchte $y(x)$. (vgl. Lagrange-Gleichung 2. Art)
 
 \begin{beispiel*}[Kürzeste Verbindung zweier Punkte in der Ebene]~\\
-	Welches Funktional? (Infitisemale Länge $\d s = \sqrt{\d x^2 \d y^2}$) Gesucht ist $\int_{p_1}^{p_2} \d s = J$\\
+	Welches Funktional? (Infinitesimale Länge $\d s = \sqrt{\d x^2 \d y^2}$) Gesucht ist $\int_{p_1}^{p_2} \d s = J$\\
 	$$J = \int_{p_1}^{p_2} \d s = \int_{x_1}^{x_2} \sqrt{\d x^2 + \d y^2} = \int_{x_1}^{y_2} \sqrt{1 + (\ddd{y}{x})^2} \d x = \int_{x_1}^{x_2} \sqrt{1 + {y'}^2} \d x$$
 	$\delta J = 0$ führt zur extremalen Bahn $y(x)$. 
 	$$ f(x, y, y') = \sqrt{1 + {y'}^2}$$
-	Nun verwenden wir die Eulergleichung: $\ffpartial{f}{y} = 0$; $\ffpartial{f}{y'} = \frac{y'}{\sqrt{1 + {y'}^2}}$ und damit folgt
+	Nun verwenden wir die Euler-Gleichung: $\ffpartial{f}{y} = 0$; $\ffpartial{f}{y'} = \frac{y'}{\sqrt{1 + {y'}^2}}$ und damit folgt
 	$$\dd x \frac{y'}{\sqrt{1 + {y'}^2}} = 0$$
 	oder anders gesagt
 	$$\frac{y'}{\sqrt{1 + {y'}^2}} = \text{konstant} = c \rightarrow {y'}^2 = c^2 ( 1 + {y'}^2)$$
@@ -2119,11 +2119,11 @@ Und damit eine Differentialgleichung 2. Ordnung für das gesuchte $y(x)$. (vgl. 
 	$${y'}^2 = \text{konstant}, y' = \text{konstant}$$
 	und damit schlussendlich die Lösung des Problems
 	$$y(x) = a x + b$$
-	$a$, $b$ werden über die Anfbangsbedingungen$(x_1, y_1)$ und $(x_2, y_2)$ festgelegt.
+	$a$, $b$ werden über die Anfangsbedingungen$(x_1, y_1)$ und $(x_2, y_2)$ festgelegt.
 \end{beispiel*}
 
 \begin{beispiel*}[Minimale Rotationsfläche]~\\
-	\textit{Es wird im Grunde genommen wie beim letzten Beispiel vorgeganen} Die Minimalfläche ist
+	\textit{Es wird im Grunde genommen wie beim letzten Beispiel vorgegangen} Die Minimalfläche ist
 	\begin{align*}
 	J &= \int \d A = \int 2 \pi x \d s
 	\intertext{mit $\d s = \sqrt{\d x^2 + \d y^2} = \sqrt{1 + (\ddd{y}{x})^2} \d x = \sqrt{1 + {y'}^2} \d x$ folgt}
@@ -2134,17 +2134,17 @@ Und damit eine Differentialgleichung 2. Ordnung für das gesuchte $y(x)$. (vgl. 
 	\begin{align*}
 	f(x,y,y') &= x \sqrt{1 + {y'}^2} & \text{~\textit{mit }}y' = \ddd{y}{x}\\
 	\ffpartial{f}{y} &= 0 & \ffpartial{f}{y'} = \frac{x y'}{\sqrt{1 + {y'}^2}}\\
-	\xRightarrow[]{\text{Eulergleichung}} \dd x \frac{x y'}{\sqrt{1 + {y'}^2}} &= 0\\
+	\xRightarrow[]{\text{Euler-Gleichung}} \dd x \frac{x y'}{\sqrt{1 + {y'}^2}} &= 0\\
 	\frac{x y'}{\sqrt{1 + {y'}^2}} &= \text{konstant} = a\\
 	\ddd{y}{x} &= y' = \frac{a}{\sqrt{x^2 - a^2}}\\
 	y(x) &= a \text{arcosh}(\frac{x}{a}) + b & \text{~\textit{oder }} x(y) = a \cosh (\frac{y - b}{a})
 	\end{align*}
 	$a$, $b$ können mit den Anfangsbedingungen gefunden werden $(x_1, y_1)$ und $(x_2, y_2)$.\\
-	Ein Hinweis am Rande: Die Kurve, welche durch den Kosinushyperbolikus beschrieben wird, wird auch Kettenlinie\footnote{\href{https://de.wikipedia.org/wiki/Kettenlinie_\%28Mathematik\%29}{Wikipedia}} genannt.
+	Ein Hinweis am Rande: Die Kurve, welche durch den Kosinus Hyperbolicus beschrieben wird, wird auch Kettenlinie\footnote{\href{https://de.wikipedia.org/wiki/Kettenlinie_\%28Mathematik\%29}{Wikipedia}} genannt.
 \end{beispiel*}
 
-\textbf{Hamiltonisches Prinzip}
-Das Integralprinzip (Hamilton) und das differentielle Prinzip (d'Alembert) sind äquivalent. Beide führen auf die Lagrangegleichungen. 
+\textbf{Hamiltonsches Prinzip}
+Das Integralprinzip (Hamilton) und das differentielle Prinzip (d'Alembert) sind äquivalent. Beide führen auf die Lagrange-Gleichungen. 
 
 \subsubsection{Erhaltungsgrößen}
 \paragraph{Allgemeines System} Die allgemeinen Koordinaten $q_i$, $\dot{q}_i$ für $i = 1, \dots, s$ sind im Laufe der Zeit veränderlich, womit es $2S$ Funktionen der Zeit gibt. Einige von diesen sind jedoch konstant\footnote{Mathematisch ausgedrückt gilt dann $F_r = F_r(q_1, \dots, q_s, \dot{q}_1, \dot{q}_s, t) = \text{konstant}$.}, was nicht Zufall sein muss.\footnote{Es ist aus offensichtlichen das Ziel, dass möglichst viele Funktionen konstant sind. Denn wie man schon im Lagrange-Teil gesehen hat, wird damit die Komplexität des Problems reduziert.}
@@ -2162,7 +2162,7 @@ Ein gutes Beispiel hierfür sind Zweikörperprobleme.
 	Zwei Massepunkte $m_1$ und $m_2$ haben die Koordinaten $\vec{r}_1$ und $\vec{r}_2$ und die Relativkoordinate $\vec{r} = \vec{r}_i - \vec{r}_2$. Als Kraft herrscht nur das Potentialfeld\footnote{Nur abhängig von der relativen Position der Massepunkte. Beispiele hierfür sind das Gravitationsfeld oder das elektrische Feld}
 	\begin{align*}
 	V(\vec{r}_1, \vec{r}_2) &= V(| \vec{r}_1 - \vec{r}_2|) = V(r)\\
-	\text{Gesammtmasse~~~} M &= m_1 + m_2\\
+	\text{Gesamtmasse~~~} M &= m_1 + m_2\\
 	\text{reduzierte Masse~~~} \mu &= \frac{m_1 m_2}{m_1 + m_2}\\
 	\text{Schwerpunkt~~~} R &= \frac{1}{M} (m_1 \vec{r}_1 + m_2 \vec{r}_2)\\
 	\text{Relativkoordinate~~~} \vec{r} &= \vec{r}_1 - \vec{r}_2 = r (\sin \vartheta \cos \varphi, \sin \vartheta \sin \varphi, \cos \vartheta)
@@ -2173,13 +2173,13 @@ Ein gutes Beispiel hierfür sind Zweikörperprobleme.
 	Die generalisierten Koordinaten sind in unserem Beispiel
 	\begin{align*}
 	\vec{R} &= (q_1, q_2, q_3) \text{~mit~} r = q_4, \vartheta = q_5, \varphi = q_6
-	\intertext{Damit ist die Lagrangefunktion in den generalisierten Koordinaten}
+	\intertext{Damit ist die Lagrange-Funktion in den generalisierten Koordinaten}
 	L &= \frac{M}{2} (\dot{q}_1^2 + \dot{q}_2^2 + \dot{q}_3^2) \\~&- V(q_4) + \frac{\mu}{2} (\dot{q}_4^2 + q_4^2 \dot{q}_5^2 + q_4^2 \dot{q}_6^2 \sin^2 q_5)
-	\intertext{Offensichtlich sind die Koordinaten $q_1, q_2, q_3, q_6$ zyklisch und $p_i = \ffpartial{L}{\dot{q}_i} = M \dot{q}_i$ für ($i =1, 2, 3$), also bleibt der \textit{Schwerpunktsimpuls} erhalten.}
+	\intertext{Offensichtlich sind die Koordinaten $q_1, q_2, q_3, q_6$ zyklisch und $p_i = \ffpartial{L}{\dot{q}_i} = M \dot{q}_i$ für ($i =1, 2, 3$), also bleibt der \textit{Schwerpunktimpuls} erhalten.}
 	\vec{p} &= M \dotvec{R} = \text{konstant}\\
 	p_6 &= \ffpartial{L}{\dot{q}_6} = \mu q_4^2 \dot{q}_6 \sin^2 q_5 = \mu \dot{\varphi} r^2 \sin^2 \vartheta = L_r^{(Z)} = \text{konstant}\\
 	\intertext{Die $z$-Komponente des Relativdrehimpulses ist ersichtlicherweise konstant\footnote{Vergleiche: Geworfenes Frisbee, dessen Drehachse relativ gesehen sich nicht verändert.\footnote{Tipp: Dies mit einer Tafelkreide zu probieren ist aufgrund des vergleichsweise geringen Impulses schlecht möglich.}}}
-	\intertext{Wenn man das Problem nun versucht in den Kartesischen Koordinaten anzugehen, führt das folgender Langrange-Funktion}
+	\intertext{Wenn man das Problem nun versucht in den Kartesischen Koordinaten anzugehen, führt das folgender Lagrange-Funktion}
 	L &= \frac{m_1}{2} (\dot{x}_1^2 + \dot{y}_1^2 + \dot{z}_1^2) + \frac12 m_2 (\dot{x}_2^2 + \dot{y}_2^2 + \dot{z}_2^2) \\
 	~&- V((x_1 - x_2)^2 + (y_1 - y_2)^2 + (z_1 - z_2)^2)
 	\intertext{Auch hier sind die Erhaltungssätze ebenso gültig. Sie sind aber viel schwerer abzulesen.}
@@ -2189,14 +2189,14 @@ Ein gutes Beispiel hierfür sind Zweikörperprobleme.
 
 \subsubsection{Homogenität in der Zeit}
 Das bedeutet die Invarianz der Bewegung gegenüber Zeittranslationen bei gleichen Anfangsbedingungen.\\
-Hamiltonfunktion:
+Hamilton-Funktion:
 $$H = \sum_{j=1}^s p_j \dot{q}_j - L$$
 für die nach Konstruktion gilt $\ddd{H}{t} = 0$, oder anders ausgedrückt, dass $H = \text{konstant}$ gilt.
 
 \subsubsection{Interpretation von $H$} \dots für konservative Systeme mit holonom-skleronomen Zwangsbedingungen.
 $$T = \frac12 \sum_{i=1}^N m_i \dotvec{r}_i^2$$
 
-Man kann die Hamiltonfunktion als Gesamtenergie des Systems interpretieren.
+Man kann die Hamilton-Funktion als Gesamtenergie des Systems interpretieren.
 
 
 
@@ -2206,7 +2206,7 @@ Man kann die Hamiltonfunktion als Gesamtenergie des Systems interpretieren.
 \paragraph{Zusammengefasst}
 Aus der Homogenität in der Zeit folgt
 \[H=\sum\limits_{j=1}^S p_j\dot q_j - L = \const\]
-Falls die Zwangsbedingungen skleronom sind, folgt daraus die \emph{Energieerhaltung}, denn die Hamiltonfunktion ist die Gesamtenergie.
+Falls die Zwangsbedingungen skleronom sind, folgt daraus die \emph{Energieerhaltung}, denn die Hamilton-Funktion ist die Gesamtenergie.
 
 \subsubsection{Homogenität des Raums}
 Wenn etwas räumlich homogen ist, bedeutet, dass es unabhängig vom Ort (Anfangsbedingungen). Eine Verschiebung des Systems verändert nicht die Dynamik. Damit ist ein solches System in der Regel nur von den relativen Abständen abhängig.
@@ -2219,11 +2219,11 @@ Die Homogenität des Raums ist genau dann vorhanden, wenn \emph{Impulserhaltung}
 \end{bemerkung*}
 
 \section{Hamilton-Mechanik}
-Der Ausgangspunkt ist offensichtlich die Lagrangemechanik. Jetzt wird $(\vec q, \dot {\vec q})$ zu $(\vec q, \vec p, t)$ transformiert.
+Der Ausgangspunkt ist offensichtlich die Lagrange-Mechanik. Jetzt wird $(\vec q, \dot {\vec q})$ zu $(\vec q, \vec p, t)$ transformiert.
 
 Die $p_i$ sind die zu $q_i$ kanonisch konjugierten Impulse, sie werden als unabhängige Funktion (von $\vec q$) aufgefasst.
-\[\text{Lagange}\to\text{Hamilton}\]
-\[\text{$S$ Differentialgleichungen 2. Ordnung}\to\text{$2S$ Differentialgleichungen 1. Ordung}\]
+\[\text{Lagrange}\to\text{Hamilton}\]
+\[\text{$S$ Differentialgleichungen 2. Ordnung}\to\text{$2S$ Differentialgleichungen 1. Ordnung}\]
 \[\text{$2S$ Anfangsbedingungen}\to\text{$2S$ Anfangsbedingungen}\]
 Der Übergang von $q_j$ nach $p_j$ geschieht per Legendre-Transformation, die im folgenden kurz erklärt wird.
 \subsubsection{Legendre - Transformation} \textit{als mathematisches Werkzeug}\\
@@ -2275,9 +2275,9 @@ dann für $H$:
 $$\dot{p}_j = 0 = -\ffpartial{H}{q_j}$$
 \conseq zyklische Koordinaten erscheinen auch nicht in H.
 $p_j$ durch die Anfangsbedingung $p_j = c_j$ festgelegt. System also praktisch nur noch $(2S -2)$ Freiheitsgrade.
-$H$ nicht mehr von $q_j$, $p_j$ abhängig. Vgl. $L$, hier immer noch $\dot{q}_j$ Abhändigkeit in der Lagrangefunktion, d.h. wir haben hier einen klaren Vorteil des Hamiltonformalismus.
+$H$ nicht mehr von $q_j$, $p_j$ abhängig. Vgl. $L$, hier immer noch $\dot{q}_j$ Abhängigkeit in der Lagrange-Funktion, d.h. wir haben hier einen klaren Vorteil des Hamilton-Formalismus.
 
-\subsubsection{Vorgehen im Hamiltonformalismus als Rezept}
+\subsubsection{Vorgehen im Hamilton-Formalismus als Rezept}
 \begin{enumerate}
 	\item generalisierte Koordinaten $\vec{q} = (q_1, \dots, q_s)$
 	\item $\vec{r}_i = \vec{r}_(q_1, \dots, q_s, t)$ und auch $\dotvec{r}_i = \dotvec{r}_i(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t)$
@@ -2287,9 +2287,9 @@ $H$ nicht mehr von $q_j$, $p_j$ abhängig. Vgl. $L$, hier immer noch $\dot{q}_j$
 	$$p_j = \ffpartial{L}{\dot{q}_j} \Rightarrow p_j = p_j(\vec{q}, \dotvec{q}, t)$$
 	\item Lösen für $\dot{q}_j$
 	$$\dot{q}_j = \dot{q}_j (\vec{q}, \vec{p}, t)$$
-	\item Lagrangefunktion
+	\item Lagrange-Funktion
 	$$l(\vec{q}, \dotvec{q}(\vec{q}, \vec{p}, t), t) = \tilde{L}(\vec{q}, \vec{p}, t)$$
-	\item Legendretransformation
+	\item Legendre-Transformation
 	$$H(\vec{q}, \vec{p}, t) = \sum_{j=1}^s p_j \dot{q}_j(\vec{q}, \vec{p}, t) - \tilde{L}(\vec{q}, \vec{p}, t)$$
 	\item kanonische Gleichungen aufstellen und lösen
 \end{enumerate}
@@ -2354,7 +2354,7 @@ harmonischer Oszillator im Konfigurationsraum ohne zeitliche Information.
 $$\vec{q} = (q_1, \dots, q_s) \text{~und~} t \text{\textit{\qquad S dimensional}}$$
 \conseq Bahn $\vec{q}(t)$ aus $2S$ Anfangsbedingungen. \textit{Wo ist der Harmonische Oszillator zur Zeit $t$.}\\
 
-Im Hamiltonformalismus:
+Im Hamilton-Formalismus:
 
 \subsubsection{Phasenraum}
 $$\vec{q} = (q_1, \dots, q_s) \text{~und~} \vec{p} = (p_1, \dots, p_s) \text{\textit{\qquad S dimensional}}$$
@@ -2375,7 +2375,7 @@ Der Orts- und der Impulsvektor
 \vec{q} &= (q_1, \dots, q_s) & \vec{p} &= (p_1, \dots, p_s) & t
 \end{align*}
 legen das ganze System fest.\\
-Die Punkte im Zustandsraum $\vec{\pi} (t)$ werden im Hamiltonformalismus durch eine Differentialgleichung 1. Ordnung beschrieben.
+Die Punkte im Zustandsraum $\vec{\pi} (t)$ werden im Hamilton-Formalismus durch eine Differentialgleichung 1. Ordnung beschrieben.
 $$\vec{\pi}(t_0) \xrightarrow{\text{Kenntnis von $H$}} \vec{\pi}(t \neq t_0)$$
 
 \invisible{\paragraph{Begriff des Zustandes $\Psi$}
@@ -2389,7 +2389,7 @@ $$\dot{\Psi}(t) = \tilde{\Psi}(\Psi(t))$$
 \textit{In der Quantenmechanik ist dies die Schrödingergleichung.}\\
 Daraus folgen die Hamiltonschen kanonischen Gleichungen
 $$\dotvec \pi (t) = \tilde{\Psi}(\vec{\pi}(t))$$
-Die Hamiltonfunktion spielt eine fundamentale Rolle.
+Die Hamilton-Funktion spielt eine fundamentale Rolle.
 }
 }
 
@@ -2408,18 +2408,18 @@ Die Hamiltonfunktion spielt eine fundamentale Rolle.
 \poisson{q_i, p_j} &= \delta_{ij}
 \end{align*}
 
-\subsubsection{Die fundamentalen Poissonklammern}
+\subsubsection{Die fundamentalen Poisson-Klammern}
 \begin{align*}
 \poisson{q_i, q_j} &= \poisson{p_i, p_j} = 0\\
 \poisson{q_i, p_j} &= \delta_{ij}
 \end{align*}
 
-Die Poissonklammern hängen nicht von der Wahl der kanonisch konjugierten Variablen ab.
+Die Poisson-Klammern hängen nicht von der Wahl der kanonisch konjugierten Variablen ab.
 
 $$\{F, G\}_{\vec{q}, \vec{p}} = \{F, G\}_{\vec{Q}, \vec{P}} = \{F, G\}$$
-Die Poissonklammer kann auch als algebraisches Konstrukt mit den folgenden Eigenschaften betrachtet werden 
+Die Poisson-Klammer kann auch als algebraisches Konstrukt mit den folgenden Eigenschaften betrachtet werden 
 \begin{description}
-	\item[Linerarität] $\{c_1 f_1 + c_2 f_2, g\} = c_1 \{f_1, g\} + c_2 \{f_2, g\}$ ($c_1$, $c_2$ konstant)
+	\item[Linearität] $\{c_1 f_1 + c_2 f_2, g\} = c_1 \{f_1, g\} + c_2 \{f_2, g\}$ ($c_1$, $c_2$ konstant)
 	\item[Antisymmetrie] $\{f, g\} = - \{g, f\}$ \conseq ${f, f} = 0$
 	\item[Nullelement] $\{c, f\} = 0$, $f=f(\vec{q}, \vec{p})$; $c = \const$
 	\item[Produktregel] $\{f, g h\} = g \{f, h\} + \{f, g\} h$
@@ -2437,7 +2437,7 @@ D.h. für \textit{Integrale der Bewegung}
 $\ddd{f}{t} = 0 \Leftrightarrow \{H, f\} = \ffpartial{f}{t}$
 insbesondere, wenn $f$ nicht explizit zeitabhängig. Kenntnis der Integrale der Bewegung wesentlich für die Lösung eines dynamischen Problems \conseq Hier: einfaches Kriterium.
 Einfacher Test: $f = H$: $\ddd{H}{t} = \{H, H\} + \ffpartial{H}{t} = \ffpartial{H}{t}$ schon bekannt. (bei skeleronomen Zwangsbedingungen = Energiesatz) 
-Bis hierhin ausführliche Diskussion der Poissonklammern als mathematisches Werkzeug der klassischen Mechanik.
+Bis hierhin ausführliche Diskussion der Poisson-Klammern als mathematisches Werkzeug der klassischen Mechanik.
 \conseq jetzt die abstrakten Eigenschaften der Klammer werden verallgemeinert
 Das gibt uns eine andere Realisierung der Klammer, was uns (fast) die ganze Quantenmechanik gibt.
 
@@ -2447,7 +2447,7 @@ Das gibt uns eine andere Realisierung der Klammer, was uns (fast) die ganze Quan
 %Formale Entwicklung der Theorie führten zu radikalen Konsequenzen (eventuell etwas Allgemeine Relativitätstheorie)
 
 \paragraph{Begriff} Wie beobachtet man physikalische Phänomene \textbf{relativ} zueinander bewegter Bezugssysteme? Und wie steht es um die Invarianz/Kovarianz physikalischer Observablen und Gesetze.
-Bei gleichförmig geradlinig zueinander bewegten Systemen (Inertialsysteme) wird die \textbf{speizielle} Relativitätstheorie angewendet, darüber hinaus gibt es für gegeneinander beschleunigt bewegte Bezugssysteme die \textbf{allgemeine} Relativitätstheorie: Aus den Beschleunigungen folgen Scheinkräfte und die Gravitationkräfte werden als Eigenschaft von Raum und Zeit beschrieben.
+Bei gleichförmig geradlinig zueinander bewegten Systemen (Inertialsysteme) wird die \textbf{spezielle} Relativitätstheorie angewendet, darüber hinaus gibt es für gegeneinander beschleunigt bewegte Bezugssysteme die \textbf{allgemeine} Relativitätstheorie: Aus den Beschleunigungen folgen Scheinkräfte und die Gravitationskräfte werden als Eigenschaft von Raum und Zeit beschrieben.
 
 Im folgenden betrachten wir "`nur"' die spezielle Relativitätstheorie.
 Das wichtigste Kriterium für sogenannte relativistische Phänomene sind die Geschwindigkeiten aller beteiligten Systeme:
@@ -2622,7 +2622,7 @@ y'&=y\\
 z'&=\gamma (z - \beta c t)\\
 ct' &= \gamma (ct - \beta z)
 \end{align*}
-Dies sind die \textbf{Lorentztransformationsformeln}. Die Zeit wird offensichtlich mittransformiert, dies war bei der Galilei-Transformation nicht der Fall
+Dies sind die \textbf{Lorentz-Transformationsformeln}. Die Zeit wird offensichtlich mit transformiert, dies war bei der Galilei-Transformation nicht der Fall
 
 \begin{bemerkung*}
 	Der Grenzfall bei $v \ll c$ ist die Galilei-Transformation.
@@ -2720,7 +2720,7 @@ wobei gilt \textit{Eulersche Formel}
 $$r e^{\pm i \phi} = r \cos\phi \pm i \sin\phi$$
 damit gilt für das Betragsquadrat offensichtlich
 $$|z_k|^2 = r_k^2$$
-und für die Multiplation zweier komplexer Zahlen
+und für die Multiplikation zweier komplexer Zahlen
 $$z_1 z_2 = r_1 r_2 e^{i (\phi_1 + \phi_2)}$$
 
 $z_k$ ist sozusagen ein "`Vektor"' in der komplexen Zahlenebene, also im zweidimensionalen Raum $\setC$. Die Multiplikation entspricht hierbei einer gemeinsamen Rotation um beide Winkel und einer kombinierten Streckung um beide Beträge.  
@@ -2826,7 +2826,7 @@ Welche Funktion $\phi(t)$ gibt 2-mal abgeleitet sich selbst mit $-\omega^2$ als 
 Ansatz: $\phi_A(t) = c e^{\pm i \omega t}$\\
 Test: $\dot{\phi_A(t)} = c (\pm i \omega) e^{\pm i \omega t}$ und $\ddot{\phi_A(t)} = c (\pm i \omega)^2 e^{\pm i \omega t} = - \omega^2 \phi_A(t)$\\
 Allgemein: $\phi(t) = c_1 e^{i \omega t} + c_2 e^{- i \omega t}$. Was sind die Werte von $c_1$ und $c_2$?\\
-Man gewinnt sie aus den Anfangsbedigungen $\phi_0$ und $\dot{\phi(t = 0)}$: $\phi(t = 0) = c_1 + c_2 = \phi_0$ und $\dot{\phi(t = 0)} = i \omega (c_1 - c_2) = \dot{\phi_0} = \omega$\\
+Man gewinnt sie aus den Anfangsbedingungen $\phi_0$ und $\dot{\phi(t = 0)}$: $\phi(t = 0) = c_1 + c_2 = \phi_0$ und $\dot{\phi(t = 0)} = i \omega (c_1 - c_2) = \dot{\phi_0} = \omega$\\
 Bemerkung: mit $\phi_a(t) = c e^{\pm i \omega t} = c (\cos(\omega t) \pm i \sin(\omega t))$ sieht man, dass die allgemeine Lösung eine Überlagerung zweier Lösungen ist, Kosinus und Sinus \dots
 
 \section{Blatt 1}
@@ -2933,7 +2933,7 @@ $x(t) = v t \cos(\alpha)$ \conseq $t = \frac{x}{v \cos(\alpha)}$ \conseq $z(t(x)
 \paragraph{Maximale Distanz?}
 \begin{itemize}
 	\item $z(\tfin) = (v \sin(\alpha)) \tfin - \frac{1}{2} g \tfin^2 \overset{!}{=} 0$ \conseq $\tfin\pm = \frac{v \sin(\alpha)}{g} \pm \sqrt{(\frac{v \sin(\alpha)}{g})^2 - 0}$ \conseq $\tfin^- = 0$ und $\tfin+ = 2 \frac{v \sin(\alpha)}{g}$
-	\item $x(\tfin^+) = \frac{2 v^2}{g} \cos(\alpha) \sin(\alpha) = \frac{2v^2}{g} \frac{\sin(2\alpha)}{2} = \frac{v^2 \sin(2 \alpha)}{g} = x(\alpha)$ mit $\sin(x + y) = \sin(x)\cos(y) + \sin(y)\cos(x)$, $x(\alpha)$ hat ein maximum $x_\text{max}$ für $\alpha = \frac{\pi}{4}$
+	\item $x(\tfin^+) = \frac{2 v^2}{g} \cos(\alpha) \sin(\alpha) = \frac{2v^2}{g} \frac{\sin(2\alpha)}{2} = \frac{v^2 \sin(2 \alpha)}{g} = x(\alpha)$ mit $\sin(x + y) = \sin(x)\cos(y) + \sin(y)\cos(x)$, $x(\alpha)$ hat ein Maximum $x_\text{max}$ für $\alpha = \frac{\pi}{4}$
 \end{itemize} 
 
 
@@ -2952,8 +2952,8 @@ Impulserhaltung: $m_1v_1 +m_2v_2 = m_1v'_1+m_2v_2'$ \conseq $m_1(v_1 - v'_1) = m
 Energieerhaltung: $m_1v_1^2 + m_2v_2^2 = m_1{v'}_1^2 + m_2{v'}_2^2 \rightarrow m_1(v_1^2-{v'}_1^2) = m_2({v'}_2^2 - v_2^2)$\\
 \conseq $m_1(v_1-{v'}_1)(v_{21}+{v'}_1) = m_2 ({v'}_2 - v_2) ({v'}_2 + v_2)$
 \conseq $v_1 + {v'}_1 = {v'}_2 + v_2$
-\conseq $v_1 - v_2 = -({v'}_1 - {v'}_2)$ \conseq die Relativgeschwingdigkeiten vor und nach dem Stoß ändern die Richtung\\
-$v_1 - v_2 = {v'}_2-{v'}_1$ und Impulserhealtung\\
+\conseq $v_1 - v_2 = -({v'}_1 - {v'}_2)$ \conseq die Relativgeschwindigkeiten vor und nach dem Stoß ändern die Richtung\\
+$v_1 - v_2 = {v'}_2-{v'}_1$ und Impulserhaltung\\
 Für ${v'}_1$: ${v'}_1$ = ${v'}_2 + v_2 - v_1$ und ${v'}_1 = \frac{1}{m_1} (-m_2 {v'}_2 + m_2v_2 + m_1v_1)$ \conseq $\frac{m_2}{m_1} {v'}_1 + {v'}_1 = 2\frac{m_2}{m_1} v_2 + v_1 (1-\frac{m_2}{m_1})$\\
 \conseq ${v'}_1 = (m_1 - m_2)v_1 + 2m_2v_2 / (m_1 + m_2)$\\
 Analog: ${v'}_1 = 2m_1v_1 + \frac{(m_2 - m_1)v_2)}{(m_1 + m_2)}$
@@ -2986,7 +2986,7 @@ $m \ddot{x} = -kx + f_0 \cos(\omega_0 t) \rightarrow \ddot{x} + \omega^2 x = \fr
 	mit $\cos(x \pm y) = \cos(x)\cos(y) \mp \sin(x)\sin(y)$
 	\conseq $\frac{f_0}{m} \cos(\omega t) = c_0 (\omega^2 - \omega_0^2) (\cos(\omega_0 t) \cos(\phi) - \sin(\omega_0 t)\sin(\phi))$
 	$0 = \cos(\omega_0 t)(c_0 (\omega^2 - \omega_0^2)\cos(\phi) - \frac{f_0}{m}) - \sin(\omega_0 t)(c_0 (\omega^2 - \omega_0^2) \sin(\phi))$
-	\\ Wenn das für alle $t$ gelten soll, so muss jeder Term, proportional zu $\cos(\omega_0 t)$ und $\sin(\omega_0 t)$, seperat verschwinden \conseq $c_0 (\omega^2 - \omega_0^2) \cos(\phi) - \frac{f_0}{m} = 0 \text{(i)}$ und $c_0 (\omega^2 - \omega_0^2) \sin(\phi) = 0 \text{(ii)}$\\
+	\\ Wenn das für alle $t$ gelten soll, so muss jeder Term, proportional zu $\cos(\omega_0 t)$ und $\sin(\omega_0 t)$, separat verschwinden \conseq $c_0 (\omega^2 - \omega_0^2) \cos(\phi) - \frac{f_0}{m} = 0 \text{(i)}$ und $c_0 (\omega^2 - \omega_0^2) \sin(\phi) = 0 \text{(ii)}$\\
 	Bestimme $c_0$ und $\phi$.
 	(i) \conseq (i*) $c_0 (\omega^2 - \omega_0^2) \cos(\phi) = \frac{f_0}{m}$\\
 	(i)/(i*) \conseq $\frac{\sin(\phi)}{\cos(\phi)} = 0 = \tan (\phi)$
@@ -2996,7 +2996,7 @@ Gesamt: $x(t) = x_0(t) + x_p(t)$\\
 $x(t) = x_0 \cos(\omega t) + \frac{v_0}{\omega} \sin(\omega t) + \frac{\frac{f_0}{m}}{\omega^2 - \omega_0^2} \cos (\omega_0 t - \phi)$
 
 \subsection{2}
-\textit{Lagrangegleichung 2. Art entspricht Euler-Lagrange-Gleichung.}
+\textit{Lagrange-Gleichung 2. Art entspricht Euler-Lagrange-Gleichung.}
 $L(\vec q, \dotvec{q}) = T(\dotvec{q}) - V(\vec{q})$\\
 $L(\vec{x}, \dotvec{x}) = \frac12 m \dotvec{x}^2 - V(\vec{x}) = \frac12 m (\dot{x}^2 + \dot{y}^2 + \dot{z}^2) - V(\vec{x})$, drei generalisierte Koordinaten und Geschwindigkeiten und für jeden Satz $(x, \dot x)$, $(y, \dot y)$, $(z, \dot z)$ gibt es eine Euler-Lagrange-Gleichung\\
 Betrachte nur x: $L(x, \dot x) = \frac12 m \dot{x}^2 - V(x)$
@@ -3029,7 +3029,7 @@ Entkopple die beiden Gleichungen: Definiere die Normalkoordinaten $\Psi_1 = \vp_
 Durch Addieren bzw. Subtrahieren der beiden Gleichungen
 $$\ddot{\Psi_1} + \frac{g}{l} \Psi_1 + 2 \frac{k}{m} \Psi_1 = 0$$
 $$\ddot{\Psi}_2 + \frac{g}{l} \Psi_2 = 0$$
-\conseq 2 entkopplte DGL
+\conseq 2 entkoppelte DGL
 $\ddot{\Phi}_1 = - (\frac{g}{l} + 2 \frac{k}{m}) \Psi_1$ mit $\omega_1^2 = \frac{g}{l} + 2 \frac{k}{m}$ und $\ddot{\Psi}_2 = - \frac{g}{l} \Psi_2$ mit $\omega_2^2 = \frac{g}{l}$, $\Psi_1$ und $\Psi_2$ unabhängige Oszillatoren, zu lösen wie gehabt.
 
 \paragraph{3 Fälle}

--- a/document.tex
+++ b/document.tex
@@ -1791,19 +1791,19 @@ Hierbei ist $\vec{F}_i$ die externe ortsabhängige Kraft, welche zum Beispiel we
 \subsubsection{Zwangsbedingungen} 
 Schränken die Bewegung von Massepunkten in einem (allgemeineren) System auf das vorgegebene System ein.
 
-\paragraph{\textit{A} holonome Zwangsbedingungen}  sind unabhängig von der Zeit, d.h. $$f_i(\vec{r}_1, \dots, \vec{r}_N, t) = 0 \text{~oder konstant}, i = 1, \dots, p$$ 
+\paragraph{\textit{A} holonome Zwangsbedingungen} Sie sind Verknüpfungen der Teilchenkoordinaten und eventuell der Zeit in folgender Form:  $$f_i(\vec{r}_1, \dots, \vec{r}_N, t) = 0 \text{~oder konstant}, i = 1, \dots, p$$ 
 
-\subparagraph{\textit{A1} holonom-skleronome Zwangsbedingungen} sind explizit von der Zeit abhängig, d.h.
+\subparagraph{\textit{A1} holonom-skleronome Zwangsbedingungen} sind \textbf{nicht} explizit von der Zeit abhängig, d.h.
 $$ \frac{\partial f_i}{\partial t} = 0, i = 1, \dots, p$$
 Beispiele: Ein Teilchen welches sich auf einer Kugeloberfläche bewegt: $x^2 + y^2 + z^2 - R^2 = 0$, Hantel: $(x_1 - x_2)^2 + (y_1 - y_2)^2 + (z_1 + z_2)^2 = l^2$ \textit{der Abstand der beiden Massepunkte ist konstant.}
 
-\subparagraph{\textit{A2} holonom-rheonome Zwangsbedingungen} sind nicht explizit, sondern nur implizit von der Zeit abhängig, d.h.
+\subparagraph{\textit{A2} holonom-rheonome Zwangsbedingungen} sind explizit von der Zeit abhängig, d.h.
 $$ \frac{\partial f_i}{\partial t} \neq 0, i = 1, \dots, p$$
 Beispiel: Ebene mit veränderlichem Winkel: $\frac{z}{x} - \tan{\phi(t)} = 0$
 
 Im folgenden quasi ausschließlich holonome Zwangsbedingungen betrachtet.
 
-\paragraph{\textit{B} nicht holonome Zwangsbedingung} können nur als Ungleichungen oder differentielle Einschränkungen.
+\paragraph{\textit{B} nicht holonome Zwangsbedingung} können nur als Ungleichungen oder differentielle Einschränkungen dargestellt werden, was die Arbeit mit ihnen, gegenüber den holonomen, erschwert.
 
 \subsubsection{Verallgemeinerte Koordinaten}
 Zwangbedingungen formulieren Zwangskräfte implizit und sind einfacher als selbige. Ziel: Elimination der Zwangskräfte.

--- a/document.tex
+++ b/document.tex
@@ -1605,7 +1605,7 @@ Masse ist Lorentzskalar. Ändert sich nicht.
 
 \chapter{Quantenmechanik}
 \section{historische Experimente und Widersprüche}
-\subsection{Hohlraumstrahlung} Die Hohlraumstrahlung ist auch als Wärmestrahlung oder Schwarzkörperstrahlung bekannt. Sie wird von einem idealisierten Raum, dessen Wände die Temperatur haben $T$, im Gleichgewicht ständig von den Wänden gleichermaßen emittiert und absorbiert. Der Raum/Körper hat keine besonderen Eigenschaften (d.h. er ist schwarz). Man beobachtet die Strahlung durch ein kleines Loch in einer der Raumwände. Es geht nun darum, eine Erklärung des beobachteten Spektrums $\ddd{E}{\nu} = w_\nu$ ($\nu$ Frequenz des Lichts) = "`Verteilung von Frequenzen $\nu$ des Lichts"' zu finden. Die Abhängigkeit derselben von der Temperatur bereitetet dabei viele Probleme.
+\subsection{Hohlraumstrahlung} Die Hohlraumstrahlung ist auch als Wärmestrahlung oder Schwarzkörperstrahlung bekannt. Sie wird von einem idealisierten Raum, dessen Wände die Temperatur $T$ haben, im Gleichgewicht ständig von den Wänden gleichermaßen emittiert und absorbiert. Der Raum/Körper hat keine besonderen Eigenschaften (d.h. er ist schwarz). Man beobachtet die Strahlung durch ein kleines Loch in einer der Raumwände. Es geht nun darum, eine Erklärung des beobachteten Spektrums $\ddd{E}{\nu} = w_\nu$ ($\nu$ Frequenz des Lichts) = "`Verteilung von Frequenzen $\nu$ des Lichts"' zu finden. Die Abhängigkeit derselben von der Temperatur bereitetet dabei viele Probleme.
 
 \paragraph{Folgerungen aus der klassischen Thermodynamik}
 Mithilfe der klassischen Thermodynamik
@@ -1642,7 +1642,7 @@ Energie / Volumen $a^3$
 	\rightarrow g(\frac{\nu}{T}) &= 8 \pi \frac{k_B}{c^3} \frac{T}{\nu}
 \end{align*}
 (Rayleigh-Jeans-Gesetz)\\
-Alternatives (phänomenologisches Gesetz (Wien)
+Alternatives phänomenologisches Gesetz (Wien)
 $$g(\frac{\nu}{T}) = a e^{- b \frac{\nu}{T}}$$
 Wir suchen eine Interpolation der Daten.\\
 Gesamtenergie $\int_0^\infty W_\nu \d \nu = \infty$ \textbf{Ultraviolettkatastrophe}\\

--- a/document.tex
+++ b/document.tex
@@ -246,16 +246,17 @@ Denn meist haben die Probleme eine durch Zwangsbedingungen eingeschränkte Geome
 \subsubsection{Zwangsbedingungen} 
 Zwangsbedingungen sind Bedingungen, welche die Bewegung von Massepunkten in einem (allgemeineren) System auf das vorgegebene System einschränken. Es gibt verschiedene Arten von Zwangsbedingungen:
 
-\paragraph{\textit{A} holonome Zwangsbedingungen} Sie sind unabhängig von der Zeit, d.h. $$f_i(\vec{r}_1, \dots, \vec{r}_N, t) = 0, i = 1, \dots, p$$ 
+\paragraph{\textit{A} holonome Zwangsbedingungen} Sie sind Verknüpfungen der Teilchenkoordinaten und eventuell der
+Zeit in folgender Form: $$f_i(\vec{r}_1, \dots, \vec{r}_N, t) = 0, i = 1, \dots, p$$ 
 Beispiel: Kreisbahn mit $f(\vec{r}, t) = x^2 + y^2 - R^2 = 0, z = 0$ und $\vec{r} = (x,y,z)^\top$ im dreidimensionalen.
 
-Holonome Zwangsbedingungen können weiter in skleronome und rheonome Zwangsbedingungen unterteilt werden:
+Holonome Zwangsbedingungen können weiter in skleronome (starre) und rheonome (fließende) Zwangsbedingungen unterteilt werden:
 
-\subparagraph{\textit{A1} holonom-skleronome Zwangsbedingungen} Sie sind explizit von der Zeit abhängig \todo{holonom-skeleronome Zwangsbed. wirklich explizit von der Zeit abhänging?}, d.h.
+\subparagraph{\textit{A1} holonom-skleronome Zwangsbedingungen} Sie sind \textbf{nicht} explizit von der Zeit abhängig, d.h.
 $$ \frac{\partial f_i}{\partial t} = 0, i = 1, \dots, p$$
 Beispiele: Ein Teilchen welches sich auf einer Kugeloberfläche bewegt: $x^2 + y^2 + z^2 - R^2 = 0$, Hantel: $(x_1 - x_2)^2 + (y_1 - y_2)^2 + (z_1 + z_2)^2 = l^2$ \textit{der Abstand der beiden Massepunkte ist konstant.}
 
-\subparagraph{\textit{A2} holonom-rheonome Zwangsbedingungen} Sie sind nicht explizit, sondern nur implizit von der Zeit abhängig, d.h.
+\subparagraph{\textit{A2} holonom-rheonome Zwangsbedingungen} Sie sind explizit von der Zeit abhängig, d.h.
 $$ \frac{\partial f_i}{\partial t} \neq 0, i = 1, \dots, p$$
 Beispiel: Ebene mit veränderlichem Winkel: $\frac{z}{x} - \tan{\phi(t)} = 0$
 

--- a/document.tex
+++ b/document.tex
@@ -280,10 +280,10 @@ Hier, wie im folgenden, werden ausschließlich holonome Zwangsbedingen betrachte
 
 Die resultierenden, linear unabhängigen, \textbf{generalisierten Koordinaten} sind $q_1, \dots, q_s$. Weiterhin ist $\vec{q} = (q_1, \dots, q_S)$
 % \in \text{Konfigurationsraum}$.
-. Die generalisierten Geschwindigkeiten lassen sich daraus als $\dot{q}_1, \dots, \dot{q}_N$ ableiten. Die alten Koordinaten lassen sich als Funktion der generalisierten Koordinaten beschreiben: $\vec{r}_i = \vec{r}_i(q_1, \dots, q_s, t)$.
+. Die generalisierten Geschwindigkeiten lassen sich daraus als $\dot{q}_1, \dots, \dot{q}_N$ ableiten. Die ursprünglichen Koordinaten lassen sich als Funktion der generalisierten Koordinaten beschreiben: $\vec{r}_i = \vec{r}_i(q_1, \dots, q_s, t)$.
 
 \paragraph{Bemerkung}
-Sofern als Anfangsbedingungen $\vec{q}_0, \dotvec{q}_0$ gegeben sind, ist der Zustand des beschränkten Systems zu jedem zu jedem Zeitpunkt bekannt. Anders ausgedrückt: Damit kann man eine Lösung des ursprünglichen Problems finden. Zwar sind die verallgemeinerten Koordinaten selbst nicht eindeutig, wohl aber ihre Anzahl.
+Sofern als Anfangsbedingungen $\vec{q}_0, \dotvec{q}_0$ gegeben sind, ist der Zustand des beschränkten Systems zu jedem Zeitpunkt bekannt. Anders ausgedrückt: Damit kann man eine Lösung des ursprünglichen Problems finden. Zwar sind die verallgemeinerten Koordinaten selbst nicht eindeutig, wohl aber ihre Anzahl.
 
 Zu beachten ist, dass diese Koordinaten keine vorgegebenen oder zwangsläufig bekannten Dimensionen oder Einheiten besitzen. Damit sind sie zwar einfacher in der Verwendung aber eventuell weniger anschaulich.
 \paragraph{Beispiele}
@@ -306,11 +306,11 @@ Damit gibt es $S = 6 - 4= 2$ Freiheitsgrade. Die verallgemeinerten Koordinaten k
 
 \subsection{Das d'Alembertsche Prinzip}
 
-\subsubsection{Ziel} Das Ziel dieses Prinzips is die Elimination der Zwangskräfte aus den Bewegungsgleichungen, wie auch ein formalerer Einblick in die Materie, wobei nur ersteres für die Vorlesung interessant ist.
+\subsubsection{Ziel} Das Ziel dieses Prinzips ist die Elimination der Zwangskräfte aus den Bewegungsgleichungen, wie auch ein formalerer Einblick in die Materie, wobei nur ersteres für die Vorlesung interessant ist.
 
 %Vor Elimination der Zwangskräfte \conseq Definition. Dazu
 
-\subsubsection{Virtuelle Verrückung $\delta \vec{r}_i$} Es ist eine willkürliche virtuelle/gedankliche Koordinatenänderung, die instantan\footnote{Direkt und ohne zeitliche Verzögerung.} durchgeführt wird und verträglich mit den Zwangsbedingungen ist. Daraus folgt $\delta t = 0$. Im folgenden signalisiert $\delta$ das virtuelle und $\d$ das normales Differential, die tatsächliche/reale Koordinatenänderung.
+\subsubsection{Virtuelle Verrückung $\delta \vec{r}_i$} Es ist eine willkürliche virtuelle/gedankliche Koordinatenänderung, die instantan\footnote{Direkt und ohne zeitliche Verzögerung.} durchgeführt wird und verträglich mit den Zwangsbedingungen ist. Daraus folgt $\delta t = 0$. Im folgenden signalisiert $\delta$ das virtuelle und $\d$ das normale Differential, die tatsächliche/reale Koordinatenänderung.
 
 \begin{beispiel*}[Teilchen im Aufzug]
 Weil der zurückgelegte Weg auch als $\delta x = v_0 \cot \Delta t$ dargestellt werden kann gilt
@@ -324,7 +324,7 @@ die Kraft entlang der erlaubten Bewegung $\vec{K}_i$ und die Zwangskraft $\vec{Z
 $$\delta W = - \vec{F} \delta \vec{r}$$
 Wenn man darin die obere Gleichung als $\vec{F}_i = \vec{K}_i - m \ddotvec{r}_i + \vec{Z}_i$ einsetzt folgt
 $$\sum_i (\vec{K}_i - m \ddot{\vec{r}}_i) \delta \vec{r}_i + \sum_i \vec{Z}_i \delta \vec{r}_i = \delta W$$
-\todo{kären, wie es zur Formel kommt}
+\todo{klären, wie es zur Formel kommt}
 Daraus kann man das Prinzip der virtuellen Arbeit folgern, wenn gilt $\delta W = \sum_i \vec{K}_i \delta \rvec_i$.
 
 \paragraph{Prinzip der virtuellen Arbeit}

--- a/document.tex
+++ b/document.tex
@@ -841,7 +841,7 @@ Aus der Homogenität in der Zeit folgt
 Falls die Zwangsbedingungen skleronom sind, folgt daraus die \emph{Energieerhaltung}, denn die Hamiltonfunktion ist die Gesamtenergie.
 
 \subsubsection{Homogenität des Raums}
-Wenn etwas räumlich homogen ist, bedeutet, dass es unabhängig vom Ort (Anfangsbedingungen). Eine Verschiebung des Systems verändert nicht die Dynamik. Damit ist ein solches System in der Regel nur von den relativen Abständen abhängig.
+Wenn etwas räumlich homogen ist, bedeutet das, dass es unabhängig vom Ort (Anfangsbedingungen) ist. Eine Verschiebung des Systems verändert nicht die Dynamik. Damit ist ein solches System in der Regel nur von den relativen Abständen abhängig.
 
 Sei nun $\Delta q_j$ die Translation des Gesamtsystems. Bei Homogenität gilt $\frac{\partial L}{\partial q_j} = 0$ und damit, dass $q_j$ zyklisch und $p_j = \frac{\partial L}{\partial \dot q_j} = \const$ ist.
 
@@ -878,12 +878,12 @@ Isotropie  $\Leftrightarrow$ Drehimpulserhaltung
 \end{bemerkung*}
 
 \section{Hamilton-Mechanik}
-Die Hamiltonsche Mechanik ist eine Weiterentwicklung der Lagrangemechanik. Sie ist ein a posteriori\footnote{"'Eine Theorie, die a posteriori gebildet wurde, erfüllt hinsichtlich ihrer Wissenschaftlichkeit zunächst nur das Kriterium der Erklärungskraft und muss sich in anderer Hinsicht (Nachvollziehbarkeit, Überprüfbarkeit, Falsifizierbarkeit, Voraussagekraft) noch bewähren."' \href{https://de.wikipedia.org/wiki/A_posteriori}{wikipedia}} wichtiger Schritt auf dem Weg zur Quantenmechanik. Die Klassische Mechanik später zum "`Grenzfall"' der Übergeordneten Quantenmechanik. Ein der Quantenmechanik ähnliche mathematische Struktur lässt sich bereits hier entwickeln.
+Die Hamiltonsche Mechanik ist eine Weiterentwicklung der Lagrangemechanik. Sie ist ein a posteriori\footnote{"'Eine Theorie, die a posteriori gebildet wurde, erfüllt hinsichtlich ihrer Wissenschaftlichkeit zunächst nur das Kriterium der Erklärungskraft und muss sich in anderer Hinsicht (Nachvollziehbarkeit, Überprüfbarkeit, Falsifizierbarkeit, Voraussagekraft) noch bewähren."' \href{https://de.wikipedia.org/wiki/A_posteriori}{wikipedia}} wichtiger Schritt auf dem Weg zur Quantenmechanik. Die Klassische Mechanik wird später zum "`Grenzfall"' der Übergeordneten Quantenmechanik. Ein der Quantenmechanik ähnliche mathematische Struktur lässt sich bereits hier entwickeln.
 
 Der Ausgangspunkt ist offensichtlich die Lagrangemechanik. Jetzt wird $(\vec q, \dot {\vec q})$ zu $(\vec q, \vec p, t)$ transformiert.
 
 Die $p_i$ sind die zu $q_i$ kanonisch konjugierten Impulse, sie werden als unabhängige Funktion (von $\vec q$) aufgefasst.
-\[\text{Lagange}\to\text{Hamilton}\]
+\[\text{Lagrange}\to\text{Hamilton}\]
 \[\text{$S$ Differentialgleichungen 2. Ordnung}\to\text{$2S$ Differentialgleichungen 1. Ordung}\]
 \[\text{$2S$ Anfangsbedingungen}\to\text{$2S$ Anfangsbedingungen}\]
 Der Übergang von $q_j$ nach $p_j$ geschieht per Legendre-Transformation, die im folgenden kurz erklärt wird.
@@ -917,7 +917,7 @@ Nun transformieren wir die beide Funktionen jeweils unter Verwendung der Legendr
 Es kann gezeigt werden (nicht hier), dass die Legendre-Transformation allgemein eindeutig und damit umkehrbar ist.
 \end{beispiel*}
 \subsubsection{Legendre-Transformation für mehrere Variablen}
-Zuer betrachten wir den Fall der Funktion $f(x,y)$, bei der $y$ durch $v$ ersetzt werden soll. Hier gilt, dass
+Zuerst betrachten wir den Fall der Funktion $f(x,y)$, bei der $y$ durch $v$ ersetzt werden soll. Hier gilt, dass
 \[g(x,y) = f(x,y) - y(\frac{\partial f}{\partial y})_x\]
 die Legendre-Transformation von $f(x,y)$ bezüglich $y$ ist.
 

--- a/document.tex
+++ b/document.tex
@@ -1054,7 +1054,7 @@ $$\vec{q} = (q_1, \dots, q_s) \text{~und~} \vec{p} = (p_1, \dots, p_s) \text{\te
 \conseq Phasenraumpunkt $\vec{\pi} = (q_1, \dots, q_s, p_1, \dots, p_s)$
 beim harmonischen Oszillator
 $$\frac{p^2}{2 m E} + \frac{q^2}{\frac{2 E}{m \omega_0^2}} = 1$$
-Daraus kann man die Halbachsen 
+Daraus kann man die folgende Halbachsen bestimmen
 \begin{align*}
 A &= \sqrt{\frac{2 E}{m \omega_0^2}}  &   B &= \sqrt{2 m E}
 \end{align*}
@@ -1139,7 +1139,7 @@ Weiter mit dem Phasenraumfunktionen für unterschiedliche kanonisch konjugierte 
 $F$, $G$; $\vec{q}$, $\vec{p}$ bzw. $\vec{Q}$, $\vec{P}$ wie oben
 \begin{align*}
 \poisson{F, G} &= \sum_{j=1}^{s} (\ffpartial{F}{q_j} \ffpartial{G}{p_i} - \ffpartial{F}{p_i} \ffpartial{G}{q_j})
-\intertext{Jetzt wird angenommen, dass $G = G(\vec{Q}, \vec{P})$ gilt, dass also $G$ von $\vec{P}$ und $\vec{Q}$ abhängig ist.}
+\intertext{Jetzt wird angenommen, dass $G = G(\vec{Q}, \vec{P})$ gilt. Also $G$ von $\vec{P}$ und $\vec{Q}$ abhängig ist.}
 &= \sum_{l,j=1}^{s} (\ffpartial{F}{q_i} (\ffpartial{G}{Q_l} \ffpartial{Q_l}{p_j} + \ffpartial{G}{P_l} \ffpartial{P_l}{p_j})  - \ffpartial{F}{p_j} (\ffpartial{G}{Q_l} \ffpartial{Q_l}{q_j} + \ffpartial{G}{P_l} \ffpartial{P_l}{q_j}))\\
 &= \sum_{l=1}^s (\ffpartial{G}{Q_l} \poisson{F, Q_l} + \ffpartial{G}{P_l} \poisson{F, P_l})      \qquad \text{\circled{$\ast$}}
 \intertext{Speziell für $F = Q_k$ oder $F = P_k$ gilt}
@@ -1188,10 +1188,10 @@ Das gibt uns eine andere Realisierung der Klammer, was uns (fast) die ganze Quan
 \newcommand{\fihbar}{\frac{1}{i \hbar}}
 
 \section{Ausblick auf die Quantenmechanik}
-Jetzt sei $\{,\}$ eine abstrakte Klammer mit den abstrakte Eigenschaften der Poissonklammer, wie verstehen diese als mathematische Struktur.
+Jetzt sei $\{,\}$ eine abstrakte Klammer mit den abstrakte Eigenschaften der Poissonklammer, wir verstehen diese als mathematische Struktur.
 Eine Realisierung dieser Struktur ist die Poissonklammer \conseq klassische Mechanik.
 Alternativ: \textit{Quantenmechanik}
-Hier Observablen sind lineare Operatoren $A$, $B$, $C$, \dots auf Hilberträumen. Z.B. $A,B,C = $ Matrizen auf gewähnlichen Vektoren. Definiere Klammer jetzt als Kommutator $[A,B] = AB - BA$
+Hier sind Observablenlineare Operatoren $A$, $B$, $C$, \dots auf Hilberträumen. Z.B. $A,B,C = $ Matrizen auf gewöhnlichen Vektoren. Definiere Klammer jetzt als Kommutator $[A,B] = AB - BA$
 als die abstrakte mathematische Struktur. Konkret können Operatoren Matrizen sein. Hier nicht Nichtkommutativität z.B. von Drehungen bekannt. "`Reihenfolge der Operatoren ist relevant"'.
 Konkrete Formulierung der Quantenmechanik auf Grund dieser mathematischen Struktur wäre folgendes
 \begin{enumerate}
@@ -1214,7 +1214,7 @@ Konkrete Formulierung der Quantenmechanik auf Grund dieser mathematischen Strukt
 %Formale Entwicklung der Theorie führten zu radikalen Konsequenzen (eventuell etwas Allgemeine Relativitätstheorie)
 
 \paragraph{Begriff} Wie beobachtet man physikalische Phänomene \textbf{relativ} zueinander bewegter Bezugssysteme? Und wie steht es um die Invarianz/Kovarianz physikalischer Observablen und Gesetze.
-Bei gleichförmig geradlinig zueinander bewegten Systemen (Inertialsysteme) wird die \textbf{speizielle} Relativitätstheorie angewendet, darüber hinaus gibt es für gegeneinander beschleunigt bewegte Bezugssysteme die \textbf{allgemeine} Relativitätstheorie: Aus den Beschleunigungen folgen Scheinkräfte und die Gravitationkräfte werden als Eigenschaft von Raum und Zeit beschrieben.
+Bei gleichförmig geradlinig zueinander bewegten Systemen (Inertialsysteme) wird die \textbf{spezielle} Relativitätstheorie angewendet, darüber hinaus gibt es für gegeneinander beschleunigt bewegte Bezugssysteme die \textbf{allgemeine} Relativitätstheorie: Aus den Beschleunigungen folgen Scheinkräfte und die Gravitationkräfte werden als Eigenschaft von Raum und Zeit beschrieben.
 
 Im folgenden betrachten wir "`nur"' die spezielle Relativitätstheorie.
 Das wichtigste Kriterium für sogenannte relativistische Phänomene sind die Geschwindigkeiten aller beteiligten Systeme:
@@ -1241,9 +1241,9 @@ Die Konsequenz für Lichtwellen, die sich in einem System $\Sigma$ sphärisch au
 Dass heißt, dass sie sich nicht wirklich sphärisch ausbreiten in $\Sigma'$. Offensichtlich scheint sich nach der klassischen Mechanik das Licht in einer Art "`Weltäther"' auszubreiten, welcher verknüpft ist mit der Idee des absolutem Raumes. Und die Behauptung ist, dass es einen \textbf{absoluten Raum} gibt in dem der Äther ruht. Hier breitet sich das Licht sphärisch aus.
 
 \subsubsection{Michelson-Morley-Experiment}
-Um die "`Äther-Behauptung"' zu verifizieren stellte der Physiker Albert A. Michelson 1881 in Potsdam und verfeinert 1887 in den USA mit dem Chemiker Edward W. Morley das nach ihnen benannte Experiment auf. Die Ironie dahinter ist, dass sie keinen Äther (dessen "`Wind"' beim durchstreifen) nachweisen konnten, ihr Experiment schlug also fehl, Morley dafür aber als erster Amerikaner 1907 den Physik Nobelpreis bekam.
+Um die "`Äther-Behauptung"' zu verifizieren stellte der Physiker Albert A. Michelson 1881 in Potsdam und verfeinert 1887 in den USA, mit dem Chemiker Edward W. Morley das nach ihnen benannte Experiment auf. Die Ironie dahinter ist, dass sie keinen Äther (bzw. dessen "`Wind"' beim durchstreifen) nachweisen konnten, ihr Experiment schlug also fehl. Morley bekam dafür aber als erster Amerikaner 1907 den Physik Nobelpreis.
 
-\paragraph{Idee} Wir Betrachten die Bewegung der Erde um die Sonne, denn die Erde driftet mit immerhin $v = 30 \mathrm{km}\mathrm{s}^{-1}$ um die Sonne durch den Weltäther. Jetzt ist die Frage, ob sich das Licht zu unterschiedlichen Jahreszeiten unterschiedlich aus? Oder ob man generell die Geschwindigkeit des Äthers relativ zur Sonne messen kann?
+\paragraph{Idee} Wir Betrachten die Bewegung der Erde um die Sonne, denn die Erde driftet mit immerhin $v = 30 \mathrm{km}\mathrm{s}^{-1}$ um die Sonne durch den Weltäther. Jetzt ist die Frage, ob sich das Licht zu unterschiedlichen Jahreszeiten unterschiedlich ausbreitet? Oder ob man generell die Geschwindigkeit des Äthers relativ zur Sonne messen kann?
 
 \paragraph{Aufbau} vgl. \href{https://de.wikipedia.org/wiki/Michelson-Morley-Experiment}{Wikipedia}
 Grob zusammen gefasst, läuft das Licht, mit Wellenlänge $\lambda$, über zwei verschiedene Wege, welche senkrecht zu einander legen. Diese beiden Wege sind gleich lang. Für eine konstruktive Interferenz der beiden resultierenden Lichtstrahlen muss die Wegdifferenz $\delta S = (S_0 - S_1 - S_0) - (S_0 - S_2 - S_0) = m \lambda$ sein.
@@ -1295,7 +1295,7 @@ $$x^{~2} = x'^2 \text{~oder~} c^2 t^2 - x^2 - y^2 - z^2 = c^2 t'^2 - x'^2 - y'^2
 Die gesuchte Transformation ist die sogenannte \textbf{Lorentztransformation}. Offenbar ist die Wahl der Koordinatenachsen willkürlich, womit wir die \textbf{spezielle Lorentztransformation} haben, welche zusammen mit einer Drehung, die allgemeine Lorentztransformation ergibt.
 
 
-Die Beziehung zwischen $x$ und $x'$ ist notwendig linear, weil nur wir nur gleichförmige und geradlinige Bewegungen betrachten.
+Die Beziehung zwischen $x$ und $x'$ ist notwendig linear, weil wir nur gleichförmige und geradlinige Bewegungen betrachten.
 $$x'^{\mu} = L^\mu_\nu x^\nu$$
 $x^\mu$ ist in dieser Schreibweise die $\mu$-te Koordinate des Vierervektors $(x^0, x^1, x^2, x^3)$  
 
@@ -1307,7 +1307,7 @@ S &= \vec{a}\cdot\vec{b} = \sum_{i=1}^{3}a_i b_i  &\rightarrow& & S&=a_ib_i\\
 (\vec{a})_i &= (M\vec{b})_i &\rightarrow& & a_i &= \sum_{j=1}^3 M_{ij} b_{j} = M_{ij}b_j\\
 \vec{a} &= L M \vec{b}  &\rightarrow& & a_i &=L_{ij}M_{jk}b_k
 \end{align*}
-Vierervektoren $x^\mu, x$, mit $x^\mu$ sind oft sowohl in der Indexschreibweise als auch als "`ganzer"' Vektor geschrieben. Weiherhin ist $x^\mu = (x^0, \vec{x})$ der kontravariante und $x_\mu = (x^0, -\vec{x})$ der kovariante Vierervektor. Das Skalarprodukt ist jetzt
+Vierervektoren $x^\mu, x$, mit $x^\mu$ sind oft sowohl in der Indexschreibweise als auch als "`ganzer"' Vektor geschrieben. Weiterhin ist $x^\mu = (x^0, \vec{x})$ der kontravariante und $x_\mu = (x^0, -\vec{x})$ der kovariante Vierervektor. Das Skalarprodukt ist jetzt
 $$x_\mu y^\mu = \sum_{\mu=0}^{3} x_\mu y^\mu = x^0y^0 - \vec{x} \vec{y}$$
 Als Konvention gilt weiterhin $\mu, \nu, \rho, \sigma \in  \{0, 1, 2, 3\}$, Index 0 ist die Zeit, $i,j,k,l \in \{1,2,3\}$ und $\cos x y = \cos(x) y$\\
 \\
@@ -1536,7 +1536,7 @@ Winkelhalbierende = Lichtkegel $\pm ct = \pm z$ und $\pm c t' = z'$
 \subsection{Zurück zur klassischen Mechanik}
 Suchen Begriffe Impuls, Kraft, Geschwindigkeit. Differentiale?
 $$\d x^\mu = (c \d t, \d x, \d y, \d z)$$
-Infitisemale Verrückung.
+Infinitesimale Verrückung.
 \conseq Invariante
 \begin{align*}
  \d s^2  &= c^2 \d t^2 (\d \vec{x})^2\\

--- a/document.tex
+++ b/document.tex
@@ -1865,8 +1865,7 @@ $$\sum_i \vec{Z}_i \delta \vec{r}_i = 0$$
 
 \paragraph{Spezialfall konservative Systeme}
 Die Kraft kann man hier als Potential $\vec{K}_i = - \vec\nabla_i V$ mit $V = V(\vec{r}_1, \dots, \vec{r}_N)$ darstellen. Und damit gilt auch
-$$Q_i = \sum_{j = 1}^N (- \frac{\partial V}{\partial \vec{r}_i} \ffpartial{\vec{r}_i}{q_j}) = - \ffpartial{V}{q_j}$$
-\todo{i und j vertauscht???}
+$$Q_j = \sum_{j = 1}^N (- \frac{\partial V}{\partial \vec{r}_i} \ffpartial{\vec{r}_i}{q_j}) = - \ffpartial{V}{q_j}$$
 
 Die Formel wird in dieser Allgemeinheit eher selten verwendet. Häufiger wird die folgende "`Version"' angewandt. Bei \textbf{holonomen Zwangsbedingungen} sind alle $q_j$ unabhängig voneinander, d.h. die $\delta q_j$  können bis auf eines unabhängig voneinander $\delta q_j = 0$ gesetzt werden. Daher muss jeder Summand 0 sein.
 $$\forall i:  \dd t ( \ffpartial{T}{\dot{q}_j}) - \ffpartial{T}{q_j} - Q_j = 0$$

--- a/document.tex
+++ b/document.tex
@@ -407,7 +407,7 @@ $$\ffpartial{V}{\dot q_j} = 0 \text{~ und damit ~} \sum_{j=1}^s \left(  \dd{t} \
 
 \subsubsection{Langangefunktion}
 Man kann die Gleichungen auch wie folgt schreiben, wenn man die Lagrangefunktion $L$ einführt.
-$$L(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t) = T(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t) - V(q_1, \dots, q_s)$$
+$$L(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t) = T(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t) - V(q_1, \dots, q_s, t)$$
 
 \subsubsection{Lagrangegleichung \textit{1. Art}}
 $$\sum_{j = 1}^s  (  \dd{t} \ffpartial{L}{\dot{q}_j} - \ffpartial{L}{q_j}  ) \delta q_j = 0$$

--- a/document.tex
+++ b/document.tex
@@ -958,24 +958,25 @@ $$q_j \text{~zyklisch} \Leftrightarrow \ffpartial{L}{q_j} = 0 \Leftrightarrow p_
 dann für $H$:
 $$\dot{p}_j = 0 = -\ffpartial{H}{q_j}$$
 \conseq zyklische Koordinaten erscheinen auch nicht in H.
-$p_j$ durch die Anfangsbedingung $p_j = c_j$ festgelegt. System also praktisch nur noch $(2S -2)$ Freiheitsgrade.
-$H$ nicht mehr von $q_j$, $p_j$ abhängig. Vgl. $L$, hier immer noch $\dot{q}_j$ Abhändigkeit in der Lagrangefunktion, d.h. wir haben hier einen klaren Vorteil des Hamiltonformalismus.
+$p_j$ wird durch die Anfangsbedingung $p_j = c_j$ festgelegt. Das System hat also praktisch nur noch $(2S -2)$ Freiheitsgrade.
+$H$ ist nicht mehr von $q_j$, $p_j$ abhängig. Vgl. $L$, hier immer noch $\dot{q}_j$ Abhändigkeit in der Lagrangefunktion, d.h. wir haben hier einen klaren Vorteil des Hamiltonformalismus.
 
 \subsubsection{Vorgehen im Hamiltonformalismus als Rezept}
 \begin{enumerate}
-	\item generalisierte Koordinaten $\vec{q} = (q_1, \dots, q_s)$
-	\item $\vec{r}_i = \vec{r}_(q_1, \dots, q_s, t)$ und auch $\dotvec{r}_i = \dotvec{r}_i(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t)$
-	\item kinetische und potentielle Energie in Teilchenkoordinaten \conseq dann generalisierte Koordinaten.
+	\item Generalisierte Koordinaten festlegen $\vec{q} = (q_1, \dots, q_s)$
+	\item Transformationsgleichungen aufstellen $\vec{r}_i = \vec{r}_(q_1, \dots, q_s, t)$ und auch $\dotvec{r}_i = \dotvec{r}_i(q_1, \dots, q_s, \dot{q}_1, \dots, \dot{q}_s, t)$
+	\item Kinetische und potentielle Energie in Teilchenkoordinaten formulieren \conseq dann generalisierte Koordinaten.
 	$$L(\vec{q}, \dotvec{q}, t) = t(\vec{q}, \dotvec q,t  - V(\vec{q}, t))$$
-	\item generalisierte Impulse
+	\item Generalisierte Impulse berechnen
 		$$p_j = \ffpartial{L}{\dot{q}_j} \Rightarrow p_j = p_j(\vec{q}, \dotvec{q}, t)$$
 	\item Lösen für $\dot{q}_j$
 	$$\dot{q}_j = \dot{q}_j (\vec{q}, \vec{p}, t)$$
-	\item Lagrangefunktion
+	\item Lagrange-Funktion
 	$$l(\vec{q}, \dotvec{q}(\vec{q}, \vec{p}, t), t) = \tilde{L}(\vec{q}, \vec{p}, t)$$
-	\item Legendretransformation
+	\item Legendre-Transformation
 	$$H(\vec{q}, \vec{p}, t) = \sum_{j=1}^s p_j \dot{q}_j(\vec{q}, \vec{p}, t) - \tilde{L}(\vec{q}, \vec{p}, t)$$
-	\item kanonische Gleichungen aufstellen und lösen
+	\item Kanonische (Hamiltonsche) Gleichungen aufstellen und lösen
+	$$\dot{p}_i = -\ffpartial{H(q,p,t)}{q_i},~~~ \dot{q}_i = \ffpartial{H(q,p,t)}{p_i}$$
 \end{enumerate}
 
 \begin{beispiel*}[2D-Fadenpendel]

--- a/document.tex
+++ b/document.tex
@@ -361,16 +361,15 @@ $$\d \vec{r}_i = \sum_{j = 1}^{s} \frac{\partial \vec{r}_i}{\partial q_j} \d q_j
 
 Damit kann \circled{1}  wie folgt geschrieben werden
 $$\sum_{i = 1}^N \vec{K}_i \delta \vec{r}_i 
-= \sum_{i=1}^N \underbrace{\sum_{j = 1}^s \vec{K}_i \frac{\partial \vec{r}_i}{\partial q_j}}_{Q_i} \delta q_i 
-= \sum_{i = 1}^N Q_i \delta q_i$$
-\todo{letzter Ausdruck korrekt? i und j richtig???}
+= \sum_{i=1}^N \sum_{j = 1}^S \vec{K}_i \frac{\partial \vec{r}_i}{\partial q_j} \delta q_j
+= \sum_{j=1}^S \left( \underbrace{\sum_{i = 1}^N \vec{K}_i \frac{\partial \vec{r}_i}{\partial q_j}}_{Q_j} \right) \delta q_j
+= \sum_{j = 1}^S Q_j \delta q_j$$
 
-$Q_i$ sind hierbei die generalisierten Kräfte. Die Dimension der $Q_i$ ist nicht unbedingt Kraft, weil die Dimension von den $q_i$ selbst unklar ist. Jedoch ist die Einheit von $Q_i \cdot q_i$ natürlich die Energie.
+$Q_j$ sind hierbei die generalisierten Kräfte. Die Dimension der $Q_j$ ist nicht unbedingt Kraft, weil die Dimension von den $q_j$ selbst unklar ist. Jedoch ist die Einheit von $Q_j \cdot q_j$ natürlich die Energie.
 
 \paragraph{Spezialfall konservative Systeme}
 Die Kraft kann man hier als Potential $\vec{K}_i = - \vec\nabla_i V$ mit $V = V(\vec{r}_1, \dots, \vec{r}_N)$ darstellen. Und damit gilt auch
-$$Q_i = \sum_{j = 1}^N (- \frac{\partial V}{\partial \vec{r}_i} \ffpartial{\vec{r}_i}{q_j}) = - \ffpartial{V}{q_j}$$
-\todo{i und j vertauscht???}
+$$Q_j = \sum_{i = 1}^N (- \frac{\partial V}{\partial \vec{r}_i} \ffpartial{\vec{r}_i}{q_j}) = - \ffpartial{V}{q_j}$$
 
 Nun betrachten wir \circled{2}, was man auch wie folgt schreiben kann
 

--- a/document.tex
+++ b/document.tex
@@ -804,10 +804,10 @@ Das bedeutet die Invarianz der Bewegung gegenüber Zeittranslationen\footnote{Da
 \vec{q}(t_2) &= \vec{q}_0\\
 \Rightarrow \vec{q}(t_1 + t) &= \vec{q}(t_2 + t)
 \end{align*}
-Daraus folgt die zeitweise Homogenität. Sie ist offenbar erfüllt, wenn $\ddd{L}{t} = 0$\todo{richtig???}, damit bekommen wir das totale Differential
+Daraus folgt die zeitweise Homogenität. Sie ist offenbar erfüllt, da die Lagrange-Funktion L nicht explizit von der Zeit abhängt ($\ffpartial{L}{t} = 0$). Damit bekommen wir das totale Differential
 $$\ddd{L}{t} = \sum_{j=1}^{s} (\underbrace{\ffpartial{L}{q_i}}_{\dd t \ffpartial{L}{\dot{q}_j}} \dot{q}_j + \ffpartial{L}{\dot{q}_j} \ddot{q}_j) + \underbrace{\ffpartial{L}{t}}_{= 0} = \sum_{j = 1}^s [ (\dd t \ffpartial{L}{\dot{q}_j}) \dot{q}_j + \ffpartial{L}{\dot{q}_j} \ddot{q}_j] = \dd t \sum_{j=1}^s \ffpartial{L}{\dot{q}_j} \dot{q}_j$$
 also gilt insgesamt
-$$\dd t (L - \sum_{j=1}^s \ffpartial{L}{\dot{q}_j} \dot{q}_j) = 0$$\footnote{richtig???}
+$$\dd t (L - \sum_{j=1}^s \ffpartial{L}{\dot{q}_j} \dot{q}_j) = 0$$
 mit dem generalisiertem Impuls $p_j = \ffpartial{L}{\dot{q}_j}$ folgt die Hamiltonfunktion
 $$H = \sum_{j=1}^s p_j \dot{q}_j - L$$
 für die nach Konstruktion gilt $\ddd{H}{t} = 0$, oder anders ausgedrückt, dass $H = \text{konstant}$ gilt.

--- a/document.tex
+++ b/document.tex
@@ -378,18 +378,18 @@ Nun betrachten wir \circled{2}, was man auch wie folgt schreiben kann
 &= \sum_{i = 1}^N m_i \ddot{\vec{r}}_i \delta \vec{r}_i 
 = \sum_{i = 1}^N \sum_{j = 1}^s m_i \ddot{\vec{r}}_i  \ffpartial{\vec{r}_i}{q_j} \delta q_j \\
 \intertext{vgl. Produktregel mit $\dd t f \cdot g = \ddd{f}{t} \cdot g + f \cdot \ddd{g}{t} \Leftrightarrow \ddd{f}{t} \cdot g = \dd t f \cdot g - f \cdot \ddd{g}{t}$}
-&= \sum_{i=1}^N \sum_{j=1}^s m_i \{\dd{t} (\dot{\vec{r}}_i \ffpartial{\vec{r_i}}{q_j} \delta q_j) -\dot{\vec{r}}_i \dd{t} \ffpartial{\vec{r}_i}{q_j} \delta q_j \}
+&= \sum_{i=1}^N \sum_{j=1}^s m_i \left(\dd{t} (\dot{\vec{r}}_i \ffpartial{\vec{r_i}}{q_j} \delta q_j) -\dot{\vec{r}}_i \dd{t} \ffpartial{\vec{r}_i}{q_j} \delta q_j \right)
 \end{align*}
 
 $\dd t \ffpartial{\vec{r}_i}{q_j}$ kann man auch wie folgt schreiben 
-$$\dd{t} \ffpartial{\vec{r}_i}{q_j} = \sum_{l=1}^s \frac{\partial^2 \vec{r}_i}{\partial q_l \partial q_j} \frac{\d q_l}{\d t} + \frac{\partial^2 \vec{r}_i}{\partial t \partial q_j} = \fpartial{q_j} \{ \sum_{l=1}^s \ffpartial{\vec{r}_i}{q_l} \dot{q}_l + \ffpartial{\vec{r}_i}{t}\} = \ffpartial{\dot{\vec{r}}_i}{q_j}$$
+$$\dd{t} \ffpartial{\vec{r}_i}{q_j} = \sum_{l=1}^s \frac{\partial^2 \vec{r}_i}{\partial q_l \partial q_j} \frac{\d q_l}{\d t} + \frac{\partial^2 \vec{r}_i}{\partial t \partial q_j} = \fpartial{q_j} \left( \sum_{l=1}^s \ffpartial{\vec{r}_i}{q_l} \dot{q}_l + \ffpartial{\vec{r}_i}{t}\right) = \ffpartial{\dot{\vec{r}}_i}{q_j}$$
 Außerdem gilt
 $$\ffpartial{\vec{r}_i}{q_j} = \fpartial{\dot q_j} \sum_{l = 1}^s \ffpartial{\vec{r}_i}{q_l} \dot{q}_l = \ffpartial{\dot{\vec{r}}_i}{\dot{q}_j}$$
 Damit gilt zusammenfassend
 \begin{align*}
-\sum_{i = 1}^N \dot{\vec{p}}_i \delta \vec{r}_i &= \sum_{i=1}^N \sum_{j = 1}^S m_i \{ \dd{t} (\dotvec{r}_i  \ffpartial{\dot{\vec{r}}_i}{\dot{q}_j})  -\dot{\vec{r}}_i \ffpartial{\dotvec r_i}{q_j} \} \delta q_j\\ 
-&= \sum_{i=1}^N\sum_{j=1}^S m_i \{  \dd{t} (\fpartial{\dot q_j} \frac12 \dotvec{r}_i^2) -\fpartial{q_j} (\frac12 \dot{\vec{r}}_i^2) \} \delta q_j \\
-&= \sum_{j = 1}^S \{ \dd{t} \fpartial{\dot{q}_j} T - \ffpartial{T}{q_j} \} \delta q_j
+\sum_{i = 1}^N \dot{\vec{p}}_i \delta \vec{r}_i &= \sum_{i=1}^N \sum_{j = 1}^S m_i \left( \dd{t} (\dotvec{r}_i  \ffpartial{\dot{\vec{r}}_i}{\dot{q}_j})  -\dot{\vec{r}}_i \ffpartial{\dotvec r_i}{q_j} \right) \delta q_j\\ 
+&= \sum_{i=1}^N\sum_{j=1}^S m_i \left(  \dd{t} (\fpartial{\dot q_j} \frac12 \dotvec{r}_i^2) -\fpartial{q_j} (\frac12 \dot{\vec{r}}_i^2) \right) \delta q_j \\
+&= \sum_{j = 1}^S \left( \dd{t} \fpartial{\dot{q}_j} T - \ffpartial{T}{q_j} \right) \delta q_j
 \end{align*}
 Hierbei ist $T = \sum_{i = 1}^{N} \frac12 m_i \dot{\vec{r}}_i^2$ die "`Kinetische Energie"'
 und damit gilt mit dem d'Alembertsches Prinzip
@@ -403,7 +403,7 @@ $$\forall j:  \dd t ( \ffpartial{T}{\dot{q}_j}) - \ffpartial{T}{q_j} - Q_j = 0$$
 
 \paragraph{Konservatives System}
 In einem konservativen System ist die Kraft $Q_j$ auf ein Potential $V_j$ zurückzuführen. Das Potential V, und damit auch die generalisierte Kraft $Q_j = - \ffpartial{V}{q_j}$, ist unabhängig von der Geschwindigkeit $\dot{q}_j$. Anders ausgedrückt gilt
-$$\ffpartial{V}{\dot q_j} = 0 \text{~ und damit ~} \sum_{j=1}^s \{  \dd{t} \fpartial{\dot{q}_j} (T-V) - \fpartial{q_j} (T -V) \} \delta q_j = 0$$
+$$\ffpartial{V}{\dot q_j} = 0 \text{~ und damit ~} \sum_{j=1}^s \left(  \dd{t} \fpartial{\dot{q}_j} (T-V) - \fpartial{q_j} (T -V) \right) \delta q_j = 0$$
 
 \subsubsection{Langangefunktion}
 Man kann die Gleichungen auch wie folgt schreiben, wenn man die Lagrangefunktion $L$ einführt.

--- a/document.tex
+++ b/document.tex
@@ -531,7 +531,7 @@ Für die häufigsten Fälle mit \textbf{holonomen} Zwangsbedingungen und \textbf
 \subsubsection{Nichtholonome Systeme}
 Bei holonomen Systemen gibt es $S = 3N - p$ unabhängige generalisierte Koordinaten. Diese sind bei nicht-holonomen Systemen nicht mehr unabhängig.
 
-Falls die nicht-holonomen Bedingungen differentiell \todo{was bedeutet differentiell???} sind gibt es sogenannte Lagrange-Multiplikatoren, welche im folgenden erläutert werden.
+Falls die nicht-holonomen Zwangsbedingungen in differentieller Form vorliegen (also als Differentialgleichung) gibt es ein Lösungsverfahren über die Methode der sogenannten Lagrange-Multiplikatoren, welche im folgenden erläutert werden.
 
 Es gibt $\bar{p}$ nicht holonome Zwangsbedingungen und damit gilt $p \leq \bar{p}$: 
 $$i = 1, \dots, p:~~\sum_{m=1}^{3N} f_{im}(x_1, \dots, x_{3N}, t) \d x_m + f_{it}(x_1, \dots, x_{3m}, t) \d t = 0$$ 


### PR DESCRIPTION
Einzige größere inhaltliche Änderung bei den holonomen Zwangsbedingungen, da war die Erklärung afaik nicht Richtig, vgl: http://th.physik.uni-frankfurt.de/~drischke/Skript_Mechanik_II.pdf bzw. http://www.springer.com/cda/content/document/cda_downloaddocument/9783642129490-c1.pdf?SGWID=0-0-45-1008044-p174037157
