### PR TITLE
Correct spelling of Gamov (e.g. for further research)

### DIFF
--- a/document.tex
+++ b/document.tex
@@ -2021,10 +2021,10 @@ Was bedeutet das für die Wellenfunktion?
 	Untersuchen von links einlaufender Welle.
 	$$\psi_0(x) \sim e^{ik_0x} \qquad k_0^2 = \frac{2m}{\hbar^2} E$$
 	interessant $E < V_0$ (klassisch kann Teilchen den Wall nicht überwinden). (vor Wall $Ae^{ik_0x}$, Expotentieller Abfall im Wall $Ce^{-\kappa x}$, danach Welle mit $Be^{ik_0 x}$)\\
-	\conseq auslaufender Zustand transmittierte und reflektierte Welle. Rechnung führt zu sogenanntem \textbf{Gamor-Faktor} (Transmissionswahrscheinlichkeit)
+	\conseq auslaufender Zustand transmittierte und reflektierte Welle. Rechnung führt zu sogenanntem \textbf{Gamov-Faktor} (Transmissionswahrscheinlichkeit)
 	$$T (E) = e^{- \frac4\hbar \sqrt{2m (v - E)} x_0}$$
 	\conseq Teilchen landet mit Wahrscheinlichkeit $> 0$ auf der anderen Seite der Barriere, obwohl klassisch die Energie nicht ausreichte, diese zu überwinden \conseq Tunneleffekt.\\
-	\textbf{Gamor}. Anwendung auf beliebige Potentialbarriere per Approximation (als Treppenbarrieren)
+	\textbf{Gamov}. Anwendung auf beliebige Potentialbarriere per Approximation (als Treppenbarrieren)
 	$$T(E) = e^{-\frac{2}{\hbar} \int_{0}^{\infty} \sqrt{2m (V(x') - E)}~ \d x'}$$
 	Erklärung des $\alpha$-Zerfalls von Atomkernen. Spontane Aussendung von $\alpha$-Teilchen (Helium-Kerne = 2p + 2n). Keine Beeinflussung von außen (Druck, Temperatur). 
 	$\alpha$-Teilchen mit sehr charakteristischer Energie emittiert. Halbwertszeiten sehr unterschiedlich. z.B.


### PR DESCRIPTION
Spelling: Its Gamov (alternatively Gamow) not Gamor (Prof's r and v look very similar).
