### PR TITLE
WARNING: Remove wrong line

### DIFF
--- a/summary.tex
+++ b/summary.tex
@@ -74,7 +74,6 @@ das führt zu den Gleichungen:
 \paragraph{Hamilton-Rezept}
 (Wenn skleronom-holonome Zwangsbedingungen, ruhende Koordinaten, konservative Kräfte, dann $H=T+V=E$)
 generalisierte Koordinaten wählen, $L = T - V$ aufstellen, $p_i = \pd{L}{\dot q_i}$ berechnen, $H=\sum\limits_{i=1}^n\dot q_i(q,p,t)p_i-L[q,\dot q(q,p,t),t]$, $\dot q_i$ ersetzen (aus dem Impuls).
-\[\dot q_i = \pd{H}{q_i} \qquad \dot p_i = -\pd{H}{q_i} \qquad \text{aufstellen und zusammenfassen}\]
 \[\ad{H}{t}=\pd{H}{t} =-\pd{L}{t}\]
 
 \paragraph{Poisson-Klammern}


### PR DESCRIPTION
1. It was incorrect (mixup of p and q)
2. It was a direct repeat of what’s just a few lines above (line 73 in the source code)
